### PR TITLE
Add EXTERNAL_URL to be set in env

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SAML Jackson (not fiction anymore)
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fboxyhq%2Fjackson&env=DB_ENGINE,DB_TYPE,DB_URL,JACKSON_API_KEYS,DB_ENCRYPTION_KEY&envDescription=DB%20configuration%20and%20keys%20for%20encryption%20and%20authentication.Set%20to%20''%20if%20not%20applicable.&envLink=https://boxyhq.com/docs/jackson/env-variables)
+[![Deploy with Vercel](https://vercel.com/button)](<https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fboxyhq%2Fjackson&env=DB_ENGINE,DB_TYPE,DB_URL,JACKSON_API_KEYS,DB_ENCRYPTION_KEY,EXTERNAL_URL&envDescription=DB%20configuration%20and%20keys%20for%20encryption%20and%20authentication.EXTERNAL_URL%20(Usually%20https%3A%2F%2F%3Cproject-name-from-above%3E.vercel.app)%20can%20be%20set%20after%20deployment%20from%20the%20project%20dashboard.Set%20to%20''%20if%20not%20applicable.&envLink=https://boxyhq.com/docs/jackson/env-variables>)
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
 SAML service [SAML in a box from BoxyHQ]

--- a/app.json
+++ b/app.json
@@ -14,6 +14,10 @@
     "PGSSLMODE": {
       "description": "https://devcenter.heroku.com/articles/connecting-heroku-postgres#connecting-in-node-js",
       "value": "no-verify"
+    },
+    "EXTERNAL_URL": {
+      "description": "The public URL of the app. See https://boxyhq.com/docs/jackson/env-variables#external_url . Replace <HEROKU_APP_NAME> below with 'App name' from above",
+      "value": "https://<HEROKU_APP_NAME>.herokuapp.com"
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #56. Include `EXTERNAL_URL` for setting the jackson service endpoint which is then used to construct the SAML request internally. 
User will need to set below vars while deploying
For Vercel: The URL is usually https://`repo-name`.vercel.app
For Heroku: https://`app-name`.herokuapp.com

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Use the one click deploy button, set the env and deploy

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code and corrected any misspellings
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes