### PR TITLE
Fixed multiple configs match (same entityID)

### DIFF
--- a/npm/src/controller/oauth.ts
+++ b/npm/src/controller/oauth.ts
@@ -241,12 +241,15 @@ export class OAuthController implements IOAuthController {
     }
 
     // Resolve if there are multiple matches for SP login. TODO: Support multiple matches for IdP login
-    const samlConfig = samlConfigs.filter((c) => {
-      return (
-        c.clientID === session?.requested?.client_id ||
-        (c.tenant === session?.requested?.tenant && c.product === session?.requested?.product)
-      );
-    })[0];
+    const samlConfig =
+      samlConfigs.length === 1
+        ? samlConfigs[0]
+        : samlConfigs.filter((c) => {
+            return (
+              c.clientID === session?.requested?.client_id ||
+              (c.tenant === session?.requested?.tenant && c.product === session?.requested?.product)
+            );
+          })[0];
 
     if (!samlConfig) {
       throw new JacksonError('SAML configuration not found.', 403);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jackson",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jackson",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "SAML 2.0 service",
   "keywords": [


### PR DESCRIPTION
## What does this PR do?

Fixes the issue where SAML metadata has the same entity ID but for different applications.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [x] Unit tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code and corrected any misspellings
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes