### PR TITLE
Set requested tenant and product when using client_id

### DIFF
--- a/npm/src/controller/oauth.ts
+++ b/npm/src/controller/oauth.ts
@@ -236,6 +236,10 @@ export class OAuthController implements IOAuthController {
         }
       } else {
         samlConfig = await this.configStore.get(client_id);
+        if (samlConfig) {
+          requestedTenant = samlConfig.tenant;
+          requestedProduct = samlConfig.product;
+        }
       }
     } else {
       throw new JacksonError('You need to specify client_id or tenant & product', 403);


### PR DESCRIPTION
## What does this PR do?

When client_id is used the requested params don't include tenant and product. This PR adds it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- [x] Unit tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code and corrected any misspellings
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes