### PR TITLE
Support encoded tenant and product in the resource OAuth param

### DIFF
--- a/npm/src/controller/oauth.ts
+++ b/npm/src/controller/oauth.ts
@@ -142,6 +142,7 @@ export class OAuthController implements IOAuthController {
       tenant,
       product,
       access_type,
+      resource,
       scope,
       nonce,
       code_challenge,
@@ -202,6 +203,9 @@ export class OAuthController implements IOAuthController {
 
       if (!sp && access_type) {
         sp = getEncodedTenantProduct(access_type);
+      }
+      if (!sp && resource) {
+        sp = getEncodedTenantProduct(resource);
       }
       if (!sp && requestedScopes) {
         const encodedParams = requestedScopes.find((scope) => scope.includes('=') && scope.includes('&')); // for now assume only one encoded param i.e. for tenant/product

--- a/npm/src/typings.ts
+++ b/npm/src/typings.ts
@@ -67,6 +67,7 @@ export interface OAuthReqBody {
   tenant?: string;
   product?: string;
   access_type?: string;
+  resource?: string;
   scope?: string;
   nonce?: string;
   code_challenge: string;

--- a/npm/test/fixture.ts
+++ b/npm/test/fixture.ts
@@ -16,6 +16,13 @@ export const authz_request_normal_with_access_type: Partial<OAuthReqBody> = {
   client_id: 'dummy',
 };
 
+export const authz_request_normal_with_resource: Partial<OAuthReqBody> = {
+  redirect_uri: boxyhq.defaultRedirectUrl,
+  state: 'state-123',
+  resource: `tenant=${boxyhq.tenant}&product=${boxyhq.product}`,
+  client_id: 'dummy',
+};
+
 export const authz_request_normal_with_scope: Partial<OAuthReqBody> = {
   redirect_uri: boxyhq.defaultRedirectUrl,
   state: 'state-123',

--- a/npm/test/oauth.test.ts
+++ b/npm/test/oauth.test.ts
@@ -20,6 +20,7 @@ import {
   authz_request_normal,
   authz_request_normal_oidc_flow,
   authz_request_normal_with_access_type,
+  authz_request_normal_with_resource,
   authz_request_normal_with_scope,
   bodyWithDummyCredentials,
   bodyWithInvalidClientSecret,
@@ -202,6 +203,19 @@ tap.test('authorize()', async (t) => {
 
     t.test('accepts access_type', async (t) => {
       const body = authz_request_normal_with_access_type;
+
+      const response = await oauthController.authorize(<OAuthReqBody>body);
+      const params = new URLSearchParams(new URL(response.redirect_url!).search);
+
+      t.ok('redirect_url' in response, 'got the Idp authorize URL');
+      t.ok(params.has('RelayState'), 'RelayState present in the query string');
+      t.ok(params.has('SAMLRequest'), 'SAMLRequest present in the query string');
+
+      t.end();
+    });
+
+    t.test('accepts resource', async (t) => {
+      const body = authz_request_normal_with_resource;
 
       const response = await oauthController.authorize(<OAuthReqBody>body);
       const params = new URLSearchParams(new URL(response.redirect_url!).search);


### PR DESCRIPTION
## What does this PR do?

Adds support for custom OAuth param `resource` and extracts tenant and product from there if present.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Existing unit tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code and corrected any misspellings
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
