### PR TITLE
Update uffizzi workflow to latest version

### DIFF
--- a/.github/workflows/build_pr-docker-image.yaml
+++ b/.github/workflows/build_pr-docker-image.yaml
@@ -1,0 +1,103 @@
+name: Build PR Image
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  build-jackson:
+    name: Build and push `jackson`
+    runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+    if: ${{ github.event.action != 'closed' }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Generate UUID image name
+        id: uuid
+        run: echo "::set-output name=uuid::$(uuidgen)"
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ttl.sh/${{ steps.uuid.outputs.uuid }}
+          tags: |
+            type=raw,value=24h
+      - name: Build Image
+        uses: docker/build-push-action@v3
+        with:
+          context: ./
+          file: ./uffizzi/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          load: true # makes image available to docker client
+          push: false
+
+      - name: DEBUG - Image information
+        if: ${{ runner.debug }}
+        run: |
+          docker image ls ttl.sh/${{ steps.uuid.outputs.uuid }}:24h
+          docker history ttl.sh/${{ steps.uuid.outputs.uuid }}:24h
+      - name: Push Image to TTL.SH
+        run: docker push ttl.sh/${{ steps.uuid.outputs.uuid }}:24h
+
+  render-compose-file:
+    name: Render Docker Compose File
+    # Pass output of this workflow to another triggered by `workflow_run` event.
+    runs-on: ubuntu-latest
+    needs:
+      - build-jackson
+    outputs:
+      compose-file-cache-key: ${{ steps.hash.outputs.hash }}
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+      - name: Render Compose File
+        run: |
+          SAML_JACKSON_IMAGE=$(echo ${{ needs.build-saml-jackson.outputs.tags }})
+          export SAML_JACKSON_IMAGE
+          # Render simple template from environment variables.
+          envsubst < uffizzi/docker-compose.template.yml > docker-compose.rendered.yml
+          cat docker-compose.rendered.yml
+      - name: Upload Rendered Compose File as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: docker-compose.rendered.yml
+          retention-days: 2
+      - name: Serialize PR Event to File
+        run: |
+          cat << EOF > event.json
+          ${{ toJSON(github.event) }} 
+
+          EOF
+      - name: Upload PR Event as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: event.json
+          retention-days: 2
+
+  delete-preview:
+    name: Call for Preview Deletion
+    runs-on: ubuntu-latest
+    if: ${{ github.event.action == 'closed' }}
+    steps:
+      # If this PR is closing, we will not render a compose file nor pass it to the next workflow.
+      - name: Serialize PR Event to File
+        run: |
+          cat << EOF > event.json
+          ${{ toJSON(github.event) }} 
+
+          EOF
+      - name: Upload PR Event as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: preview-spec
+          path: event.json
+          retention-days: 2

--- a/.github/workflows/uffizzi-env-deploy.yaml
+++ b/.github/workflows/uffizzi-env-deploy.yaml
@@ -1,88 +1,83 @@
-name: Build Images and Create Uffizzi Environment.
+name: Deploy Uffizzi Preview
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize]
+  workflow_run:
+    workflows:
+      - 'Build PR Image'
+    types:
+      - completed
 
 jobs:
-  build-saml-jackson:
-    name: Build and Push `saml-jackson`
+  cache-compose-file:
+    name: Cache Compose File
     runs-on: ubuntu-latest
-    outputs:
-      tags: ${{ steps.meta.outputs.tags }}
-    steps:
-      - name: Set Build Variables
-        run: |
-          if [[ "$GITHUB_REF" =~ ^refs/tags/v* ]]; then
-            echo "Using TAG mode: $GITHUB_REF_NAME"
-            echo "REL_VERSION=$GITHUB_REF_NAME" >> $GITHUB_ENV
-            echo "REL_VERSION_STRICT=${GITHUB_REF_NAME#?}" >> $GITHUB_ENV
-          else
-            echo "Using BRANCH mode: v$BASE_DEV_VERSION-dev.$GITHUB_RUN_NUMBER"
-            echo "REL_VERSION=v$BASE_DEV_VERSION-dev.$GITHUB_RUN_NUMBER" >> $GITHUB_ENV
-            echo "REL_VERSION_STRICT=$BASE_DEV_VERSION-dev.$GITHUB_RUN_NUMBER" >> $GITHUB_ENV
-          fi
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Checkout git repo
-        uses: actions/checkout@v3
-      - name: Docker metadata
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: ghcr.io/${{ github.repository_owner }}/jackson-dev/jackson-${{ env.REL_VERSION_STRICT }}
-      - name: Build and Push Image to GHCR
-        uses: docker/build-push-action@v2.9.0
-        with:
-          context: ./
-          file: ./uffizzi/Dockerfile
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          push: true
-
-  render-compose-file:
-    name: Render Docker Compose File
-    runs-on: ubuntu-latest
-    needs:
-      - build-saml-jackson
     outputs:
       compose-file-cache-key: ${{ steps.hash.outputs.hash }}
+      pr-number: ${{ steps.pr.outputs.number }}
     steps:
-      - name: Checkout git repo
-        uses: actions/checkout@v3
-      - name: Render Compose File
+      - name: 'Download artifacts'
+        # Fetch output (zip archive) from the workflow run that triggered this workflow.
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "preview-spec"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/preview-spec.zip`, Buffer.from(download.data));
+      - name: 'Unzip artifact'
+        run: unzip preview-spec.zip
+      - name: Read Event into ENV
         run: |
-          SAML_JACKSON_IMAGE=$(echo ${{ needs.build-saml-jackson.outputs.tags }})
-          export SAML_JACKSON_IMAGE
-          # Render simple template from environment variables.
-          envsubst < uffizzi/docker-compose.template.yml > docker-compose.rendered.yml
-          cat docker-compose.rendered.yml
+          echo 'EVENT_JSON<<EOF' >> $GITHUB_ENV
+          cat event.json >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
       - name: Hash Rendered Compose File
         id: hash
+        # If the previous workflow was triggered by a PR close event, we will not have a compose file artifact.
+        if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
         run: echo "::set-output name=hash::$(md5sum docker-compose.rendered.yml | awk '{ print $1 }')"
       - name: Cache Rendered Compose File
+        if: ${{ fromJSON(env.EVENT_JSON).action != 'closed' }}
         uses: actions/cache@v3
         with:
           path: docker-compose.rendered.yml
           key: ${{ steps.hash.outputs.hash }}
 
+      - name: Read PR Number From Event Object
+        id: pr
+        run: echo "::set-output name=number::${{ fromJSON(env.EVENT_JSON).number }}"
+      - name: DEBUG - Print Job Outputs
+        if: ${{ runner.debug }}
+        run: |
+          echo "PR number: ${{ steps.pr.outputs.number }}"
+          echo "Compose file hash: ${{ steps.hash.outputs.hash }}"
+          cat event.json
+
   deploy-uffizzi-preview:
     name: Use Remote Workflow to Preview on Uffizzi
-    needs: render-compose-file
-    uses: UffizziCloud/preview-action/.github/workflows/reusable.yaml@v2.1.0
-    if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
+    needs:
+      - cache-compose-file
+    uses: UffizziCloud/preview-action/.github/workflows/reusable.yaml@v2
     with:
-      compose-file-cache-key: ${{ needs.render-compose-file.outputs.compose-file-cache-key }}
+      # If this workflow was triggered by a PR close event, cache-key will be an empty string
+      # and this reusable workflow will delete the preview deployment.
+      compose-file-cache-key: ${{ needs.cache-compose-file.outputs.compose-file-cache-key }}
       compose-file-cache-path: docker-compose.rendered.yml
-      username: deepak@boxyhq.com
-      server: https://app.uffizzi.com
-      project: saml-jackson-hje1
-    secrets:
-      password: ${{ secrets.UFFIZZI_PASSWORD }}
+      server: https://app.uffizzi.com/
+      pr-number: ${{ needs.cache-compose-file.outputs.pr-number }}
     permissions:
       contents: read
       pull-requests: write
+      id-token: write


### PR DESCRIPTION


## What does this PR do?

This update adds support for previews from forked repos. So any contributor should be able to see previews created from their forks of jackson.

ghcr.io is replaced with ttl.sh also in this case. The images won't be pushed to ghcr further polluting space with preview images. Instead images would be pushed to ttl.sh.

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Existing unit tests

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code and corrected any misspellings
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
