### PR TITLE
Validate the tenant and product to prevent the namespace collision

### DIFF
--- a/npm/src/controller/connection/oidc.ts
+++ b/npm/src/controller/connection/oidc.ts
@@ -7,6 +7,7 @@ import {
   IndexNames,
   validateSSOConnection,
   validateRedirectUrl,
+  validateTenantAndProduct,
 } from '../utils';
 import { JacksonError } from '../error';
 
@@ -31,6 +32,8 @@ const oidc = {
     const redirectUrlList = extractRedirectUrls(redirectUrl);
 
     validateRedirectUrl({ defaultRedirectUrl, redirectUrlList });
+
+    validateTenantAndProduct(tenant, product);
 
     const record: Partial<OIDCSSORecord> = {
       defaultRedirectUrl,

--- a/npm/src/controller/connection/saml.ts
+++ b/npm/src/controller/connection/saml.ts
@@ -13,6 +13,7 @@ import {
   IndexNames,
   validateSSOConnection,
   validateRedirectUrl,
+  validateTenantAndProduct,
 } from '../utils';
 import saml20 from '@boxyhq/saml20';
 import { JacksonError } from '../error';
@@ -54,6 +55,8 @@ const saml = {
     const redirectUrlList = extractRedirectUrls(redirectUrl);
 
     validateRedirectUrl({ defaultRedirectUrl, redirectUrlList });
+
+    validateTenantAndProduct(tenant, product);
 
     const record: Partial<SAMLSSORecord> = {
       defaultRedirectUrl,

--- a/npm/src/controller/utils.ts
+++ b/npm/src/controller/utils.ts
@@ -196,13 +196,11 @@ export const extractHostName = (url: string): string | null => {
 };
 
 export const validateTenantAndProduct = (tenant: string, product: string) => {
-  const disallowedCharacters = [':'];
-
-  if (disallowedCharacters.some((char) => tenant.includes(char))) {
-    throw new JacksonError('Tenant cannot contain the character :', 400);
+  if (tenant.indexOf(':') !== -1) {
+    throw new JacksonError('Tenant should not contain :', 400);
   }
 
-  if (disallowedCharacters.some((char) => product.includes(char))) {
-    throw new JacksonError('Product cannot contain the character :', 400);
+  if (product.indexOf(':') !== -1) {
+    throw new JacksonError('Product should not contain :', 400);
   }
 };

--- a/npm/src/controller/utils.ts
+++ b/npm/src/controller/utils.ts
@@ -194,3 +194,15 @@ export const extractHostName = (url: string): string | null => {
     return null;
   }
 };
+
+export const validateTenantAndProduct = (tenant: string, product: string) => {
+  const disallowedCharacters = [':'];
+
+  if (disallowedCharacters.some((char) => tenant.includes(char))) {
+    throw new JacksonError('Tenant cannot contain the character :', 400);
+  }
+
+  if (disallowedCharacters.some((char) => product.includes(char))) {
+    throw new JacksonError('Product cannot contain the character :', 400);
+  }
+};

--- a/npm/src/controller/utils.ts
+++ b/npm/src/controller/utils.ts
@@ -197,10 +197,10 @@ export const extractHostName = (url: string): string | null => {
 
 export const validateTenantAndProduct = (tenant: string, product: string) => {
   if (tenant.indexOf(':') !== -1) {
-    throw new JacksonError('Tenant should not contain :', 400);
+    throw new JacksonError('Tenant cannot contain the character :', 400);
   }
 
   if (product.indexOf(':') !== -1) {
-    throw new JacksonError('Product should not contain :', 400);
+    throw new JacksonError('Product cannot contain the character :', 400);
   }
 };

--- a/npm/src/directory-sync/DirectoryConfig.ts
+++ b/npm/src/directory-sync/DirectoryConfig.ts
@@ -1,6 +1,6 @@
 import type { Storable, Directory, JacksonOption, DatabaseStore, DirectoryType, ApiError } from '../typings';
 import * as dbutils from '../db/utils';
-import { createRandomSecret } from '../controller/utils';
+import { createRandomSecret, validateTenantAndProduct } from '../controller/utils';
 import { apiError, JacksonError } from '../controller/error';
 import { storeNamespacePrefix } from '../controller/utils';
 
@@ -39,6 +39,8 @@ export class DirectoryConfig {
       if (!tenant || !product) {
         throw new JacksonError('Missing required parameters.', 400);
       }
+
+      validateTenantAndProduct(tenant, product);
 
       if (!name) {
         name = `scim-${tenant}-${product}`;


### PR DESCRIPTION
## What does this PR do?

This PR validate the tenant and product to prevent the namespace collision. Disallowed the character (`:`) that are not allowed in the tenant and product name.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code and corrected any misspellings
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
