### PR TITLE
Fix for token exchange failure in IdP initiated SAML login

### DIFF
--- a/npm/src/controller/oauth.ts
+++ b/npm/src/controller/oauth.ts
@@ -637,11 +637,15 @@ export class OAuthController implements IOAuthController {
     // store details against a code
     const code = crypto.randomBytes(20).toString('hex');
 
+    const requested = isIdPFlow
+      ? { tenant: samlConnection.tenant, product: samlConnection.product }
+      : session?.requested;
+
     const codeVal: Record<string, unknown> = {
       profile,
       clientID: samlConnection.clientID,
       clientSecret: samlConnection.clientSecret,
-      requested: session?.requested,
+      requested,
     };
 
     if (session) {

--- a/npm/src/controller/oauth.ts
+++ b/npm/src/controller/oauth.ts
@@ -944,7 +944,7 @@ export class OAuthController implements IOAuthController {
           throw new JacksonError('Invalid client_secret', 401);
         }
       }
-    } else if (codeVal && codeVal.session) {
+    } else {
       throw new JacksonError('Please specify client_secret or code_verifier', 401);
     }
 

--- a/npm/test/sso/fixture.ts
+++ b/npm/test/sso/fixture.ts
@@ -214,14 +214,14 @@ export const token_req_unencoded_client_id_gen = (connectionRecords) => {
   };
 };
 
-export const token_req_idp_saml_login_wrong_secretverifier = {
+export const token_req_dummy_client_id_idp_saml_login_wrong_secretverifier = {
   grant_type: 'authorization_code',
   code: CODE,
   client_id: 'dummy',
   client_secret: 'TOP-SECRET-WRONG',
 };
 
-export const token_req_idp_saml_login = {
+export const token_req_dummy_client_id_idp_saml_login = {
   grant_type: 'authorization_code',
   code: CODE,
   client_id: 'dummy',

--- a/npm/test/sso/fixture.ts
+++ b/npm/test/sso/fixture.ts
@@ -214,9 +214,32 @@ export const token_req_unencoded_client_id_gen = (connectionRecords) => {
   };
 };
 
-export const token_req_idp_initiated_saml_login = {
+export const token_req_idp_saml_login_wrong_secretverifier = {
   grant_type: 'authorization_code',
   code: CODE,
+  client_id: 'dummy',
+  client_secret: 'TOP-SECRET-WRONG',
+};
+
+export const token_req_idp_saml_login = {
+  grant_type: 'authorization_code',
+  code: CODE,
+  client_id: 'dummy',
+  client_secret: 'TOP-SECRET',
+};
+
+export const token_req_encoded_client_id_idp_saml_login = {
+  grant_type: 'authorization_code',
+  code: CODE,
+  client_id: 'tenant=boxyhq.com&product=crm',
+  client_secret: 'TOP-SECRET',
+};
+
+export const token_req_encoded_client_id_idp_saml_login_wrong_secretverifier = {
+  grant_type: 'authorization_code',
+  code: CODE,
+  client_id: 'tenant=boxyhq.com&product=crm',
+  client_secret: 'TOP-SECRET-WRONG',
 };
 
 export const token_req_cv_mismatch = {

--- a/npm/test/sso/saml_idp_oauth.test.ts
+++ b/npm/test/sso/saml_idp_oauth.test.ts
@@ -38,11 +38,11 @@ import {
   state_not_set,
   token_req_cv_mismatch,
   token_req_encoded_client_id,
-  token_req_idp_saml_login,
+  token_req_dummy_client_id_idp_saml_login,
   token_req_unencoded_client_id_gen,
   token_req_with_cv,
   token_req_encoded_client_id_idp_saml_login,
-  token_req_idp_saml_login_wrong_secretverifier,
+  token_req_dummy_client_id_idp_saml_login_wrong_secretverifier,
   token_req_encoded_client_id_idp_saml_login_wrong_secretverifier,
 } from './fixture';
 import { addSSOConnections, databaseOptions } from '../utils';
@@ -751,7 +751,7 @@ tap.test('IdP initiated flow', async (t) => {
     const { redirect_url } = await idpEnabledOAuthController.samlResponse(<SAMLResponsePayload>responseBody);
     t.equal(new URLSearchParams(new URL(redirect_url!).search).get('code'), code);
 
-    const body = token_req_idp_saml_login_wrong_secretverifier;
+    const body = token_req_dummy_client_id_idp_saml_login_wrong_secretverifier;
 
     try {
       await idpEnabledOAuthController.token(<OAuthTokenReq>body);
@@ -819,7 +819,7 @@ tap.test('IdP initiated flow', async (t) => {
     const { redirect_url } = await idpEnabledOAuthController.samlResponse(<SAMLResponsePayload>responseBody);
     t.equal(new URLSearchParams(new URL(redirect_url!).search).get('code'), code);
 
-    const body = token_req_idp_saml_login;
+    const body = token_req_dummy_client_id_idp_saml_login;
 
     const tokenRes = await idpEnabledOAuthController.token(<OAuthTokenReq>body);
     t.ok('access_token' in tokenRes, 'includes access_token');


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

In case of IdP initiated SAML flow, codeVal will contain a `isIdPFlow` flag set to true.Later in token endpoint this will be used to skip the requested tenant product check.
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Existing unit tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code and corrected any misspellings
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
