### PR TITLE
Prevent sending multiple Allow headers in the response.

### DIFF
--- a/ee/federated-saml/api/admin/[id]/index.ts
+++ b/ee/federated-saml/api/admin/[id]/index.ts
@@ -26,7 +26,7 @@ export const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     case 'DELETE':
       return handleDELETE(req, res);
     default:
-      res.setHeader('Allow', ['GET, PUT, DELETE']);
+      res.setHeader('Allow', 'GET, PUT, DELETE');
       res.status(405).json({ data: null, error: { message: `Method ${method} Not Allowed` } });
   }
 };

--- a/ee/federated-saml/api/admin/index.ts
+++ b/ee/federated-saml/api/admin/index.ts
@@ -24,7 +24,7 @@ export const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       return handleGET(req, res);
 
     default:
-      res.setHeader('Allow', ['GET, POST']);
+      res.setHeader('Allow', 'POST, GET');
       res.status(405).json({ error: { message: `Method ${method} Not Allowed` } });
   }
 };

--- a/ee/federated-saml/api/metadata.ts
+++ b/ee/federated-saml/api/metadata.ts
@@ -13,7 +13,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     case 'GET':
       return handleGET(req, res);
     default:
-      res.setHeader('Allow', ['GET']);
+      res.setHeader('Allow', 'GET');
       res.status(405).json({ error: { message: `Method ${method} Not Allowed` } });
   }
 }

--- a/ee/federated-saml/api/sso.ts
+++ b/ee/federated-saml/api/sso.ts
@@ -19,7 +19,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     case 'GET':
       return handleGET(req, res);
     default:
-      res.setHeader('Allow', ['GET']);
+      res.setHeader('Allow', 'GET');
       res.status(405).json({ error: { message: `Method ${method} Not Allowed` } });
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13969,6 +13969,186 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@next/swc-android-arm-eabi": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.0.7.tgz",
+      "integrity": "sha512-QTEamOK/LCwBf05GZ261rULMbZEpE3TYdjHlXfznV+nXwTztzkBNFXwP67gv2wW44BROzgi/vrR9H8oP+J5jxg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-android-arm64": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.0.7.tgz",
+      "integrity": "sha512-wcy2H0Tl9ME8vKy2GnJZ7Mybwys+43F/Eh2Pvph7mSDpMbYBJ6iA0zeY62iYYXxlZhnAID3+h79FUqUEakkClw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.0.7.tgz",
+      "integrity": "sha512-636AuRQynCPnIPRVzcCk5B7OMq9XjaYam2T0HeWUCE6y7EqEO3kxiuZ4QmN81T7A6Ydb+JnivYrLelHXmgdj6A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-freebsd-x64": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.0.7.tgz",
+      "integrity": "sha512-92XAMzNgQazowZ9t7uZmHRA5VdBl/SwEdrf5UybdfRovsxB4r3+yJWEvFaqYpSEp0gwndbwLokJdpz7OwFdL3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm-gnueabihf": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.0.7.tgz",
+      "integrity": "sha512-3r1CWl5P6I5n5Yxip8EXv/Rfu2Cp6wVmIOpvmczyUR82j+bcMkwPAcUjNkG/vMCagS4xV7NElrcdGb39iFmfLg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.0.7.tgz",
+      "integrity": "sha512-RXo8tt6ppiwyS6hpDw3JdAjKcdVewsefxnxk9xOH4mRhMyq9V2lQx0e24X/dRiZqkx3jnWReR2WRrUlgN1UkSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.0.7.tgz",
+      "integrity": "sha512-RWpnW+bmfXyxyY7iARbueYDGuIF+BEp3etLeYh/RUNHb9PhOHLDgJOG8haGSykud3a6CcyBI8hEjqOhoObaDpw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.0.7.tgz",
+      "integrity": "sha512-/ygUIiMMTYnbKlFs5Ba9J5k/tNxFWy8eI1bBF8UuMTvV8QJHl/aLDiA5dwsei2kk99/cu3eay62JnJXkSk3RSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.0.7.tgz",
+      "integrity": "sha512-dLzr6AL77USJN0ejgx5AS8O8SbFlbYTzs0XwAWag4oQpUG2p3ARvxwQgYQ0Z+6EP0zIRZ/XfLkN/mhsyi3m4PA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.0.7.tgz",
+      "integrity": "sha512-+vFIVa82AwqFkpFClKT+n73fGxrhAZ2u1u3mDYEBdxO6c9U4Pj3S5tZFsGFK9kLT/bFvf/eeVOICSLCC7MSgJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.0.7.tgz",
+      "integrity": "sha512-RNLXIhp+assD39dQY9oHhDxw+/qSJRARKhOFsHfOtf8yEfCHqcKkn3X/L+ih60ntaEqK294y1WkMk6ylotsxwA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.0.7.tgz",
+      "integrity": "sha512-kvdnlLcrnEq72ZP0lqe2Z5NqvB9N5uSCvtXJ0PhKvNncWWd0fEG9Ec9erXgwCmVlM2ytw41k9/uuQ+SVw4Pihw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   },
   "dependencies": {
@@ -22459,6 +22639,78 @@
     },
     "zwitch": {
       "version": "2.0.2"
+    },
+    "@next/swc-android-arm-eabi": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.0.7.tgz",
+      "integrity": "sha512-QTEamOK/LCwBf05GZ261rULMbZEpE3TYdjHlXfznV+nXwTztzkBNFXwP67gv2wW44BROzgi/vrR9H8oP+J5jxg==",
+      "optional": true
+    },
+    "@next/swc-android-arm64": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.0.7.tgz",
+      "integrity": "sha512-wcy2H0Tl9ME8vKy2GnJZ7Mybwys+43F/Eh2Pvph7mSDpMbYBJ6iA0zeY62iYYXxlZhnAID3+h79FUqUEakkClw==",
+      "optional": true
+    },
+    "@next/swc-darwin-x64": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.0.7.tgz",
+      "integrity": "sha512-636AuRQynCPnIPRVzcCk5B7OMq9XjaYam2T0HeWUCE6y7EqEO3kxiuZ4QmN81T7A6Ydb+JnivYrLelHXmgdj6A==",
+      "optional": true
+    },
+    "@next/swc-freebsd-x64": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.0.7.tgz",
+      "integrity": "sha512-92XAMzNgQazowZ9t7uZmHRA5VdBl/SwEdrf5UybdfRovsxB4r3+yJWEvFaqYpSEp0gwndbwLokJdpz7OwFdL3Q==",
+      "optional": true
+    },
+    "@next/swc-linux-arm-gnueabihf": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.0.7.tgz",
+      "integrity": "sha512-3r1CWl5P6I5n5Yxip8EXv/Rfu2Cp6wVmIOpvmczyUR82j+bcMkwPAcUjNkG/vMCagS4xV7NElrcdGb39iFmfLg==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-gnu": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.0.7.tgz",
+      "integrity": "sha512-RXo8tt6ppiwyS6hpDw3JdAjKcdVewsefxnxk9xOH4mRhMyq9V2lQx0e24X/dRiZqkx3jnWReR2WRrUlgN1UkSQ==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-musl": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.0.7.tgz",
+      "integrity": "sha512-RWpnW+bmfXyxyY7iARbueYDGuIF+BEp3etLeYh/RUNHb9PhOHLDgJOG8haGSykud3a6CcyBI8hEjqOhoObaDpw==",
+      "optional": true
+    },
+    "@next/swc-linux-x64-gnu": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.0.7.tgz",
+      "integrity": "sha512-/ygUIiMMTYnbKlFs5Ba9J5k/tNxFWy8eI1bBF8UuMTvV8QJHl/aLDiA5dwsei2kk99/cu3eay62JnJXkSk3RSQ==",
+      "optional": true
+    },
+    "@next/swc-linux-x64-musl": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.0.7.tgz",
+      "integrity": "sha512-dLzr6AL77USJN0ejgx5AS8O8SbFlbYTzs0XwAWag4oQpUG2p3ARvxwQgYQ0Z+6EP0zIRZ/XfLkN/mhsyi3m4PA==",
+      "optional": true
+    },
+    "@next/swc-win32-arm64-msvc": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.0.7.tgz",
+      "integrity": "sha512-+vFIVa82AwqFkpFClKT+n73fGxrhAZ2u1u3mDYEBdxO6c9U4Pj3S5tZFsGFK9kLT/bFvf/eeVOICSLCC7MSgJQ==",
+      "optional": true
+    },
+    "@next/swc-win32-ia32-msvc": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.0.7.tgz",
+      "integrity": "sha512-RNLXIhp+assD39dQY9oHhDxw+/qSJRARKhOFsHfOtf8yEfCHqcKkn3X/L+ih60ntaEqK294y1WkMk6ylotsxwA==",
+      "optional": true
+    },
+    "@next/swc-win32-x64-msvc": {
+      "version": "13.0.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.0.7.tgz",
+      "integrity": "sha512-kvdnlLcrnEq72ZP0lqe2Z5NqvB9N5uSCvtXJ0PhKvNncWWd0fEG9Ec9erXgwCmVlM2ytw41k9/uuQ+SVw4Pihw==",
+      "optional": true
     }
   }
 }

--- a/pages/api/admin/connections/[clientId].ts
+++ b/pages/api/admin/connections/[clientId].ts
@@ -10,7 +10,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     case 'GET':
       return handleGET(req, res);
     default:
-      res.setHeader('Allow', ['GET']);
+      res.setHeader('Allow', 'GET');
       res.status(405).json({ error: { message: `Method ${method} Not Allowed` } });
   }
 };

--- a/pages/api/admin/connections/idp-entityid.ts
+++ b/pages/api/admin/connections/idp-entityid.ts
@@ -8,7 +8,7 @@ export const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     case 'GET':
       return handleGET(req, res);
     default:
-      res.setHeader('Allow', ['GET']);
+      res.setHeader('Allow', 'GET');
       res.status(405).json({ data: null, error: { message: `Method ${method} Not Allowed` } });
   }
 };

--- a/pages/api/admin/connections/index.ts
+++ b/pages/api/admin/connections/index.ts
@@ -17,7 +17,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     case 'DELETE':
       return handleDELETE(req, res);
     default:
-      res.setHeader('Allow', ['GET', 'POST', 'PATCH', 'DELETE']);
+      res.setHeader('Allow', 'GET, POST, PATCH, DELETE');
       res.status(405).json({ error: { message: `Method ${method} Not Allowed` } });
   }
 };

--- a/pages/api/admin/directory-sync/[directoryId]/events.ts
+++ b/pages/api/admin/directory-sync/[directoryId]/events.ts
@@ -9,7 +9,7 @@ export const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     case 'DELETE':
       return handleDELETE(req, res);
     default:
-      res.setHeader('Allow', ['DELETE']);
+      res.setHeader('Allow', 'DELETE');
       res.status(405).json({ error: { message: `Method ${method} Not Allowed` } });
   }
 };

--- a/pages/api/admin/directory-sync/[directoryId]/index.ts
+++ b/pages/api/admin/directory-sync/[directoryId]/index.ts
@@ -9,7 +9,7 @@ export const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     case 'PUT':
       return handlePUT(req, res);
     default:
-      res.setHeader('Allow', ['PUT']);
+      res.setHeader('Allow', 'PUT');
       res.status(405).json({ error: { message: `Method ${method} Not Allowed` } });
   }
 };

--- a/pages/api/admin/directory-sync/index.ts
+++ b/pages/api/admin/directory-sync/index.ts
@@ -10,7 +10,7 @@ export const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     case 'POST':
       return handlePOST(req, res);
     default:
-      res.setHeader('Allow', ['POST']);
+      res.setHeader('Allow', 'POST');
       res.status(405).json({ error: { message: `Method ${method} Not Allowed` } });
   }
 };

--- a/pages/api/admin/license.ts
+++ b/pages/api/admin/license.ts
@@ -9,7 +9,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     case 'GET':
       return handleGET(req, res);
     default:
-      res.setHeader('Allow', ['GET']);
+      res.setHeader('Allow', 'GET');
       res.status(405).json({ data: null, error: { message: `Method ${method} Not Allowed` } });
   }
 }

--- a/pages/api/admin/setup-links/index.ts
+++ b/pages/api/admin/setup-links/index.ts
@@ -17,7 +17,7 @@ export const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         await handleDELETE(req, res);
         return;
       default:
-        res.setHeader('Allow', ['GET']);
+        res.setHeader('Allow', 'POST, GET, DELETE');
         res.status(405).json({ data: null, error: { message: `Method ${method} Not Allowed` } });
     }
   } catch (error: any) {

--- a/pages/api/setup/[token]/connections/idp-entityid.ts
+++ b/pages/api/setup/[token]/connections/idp-entityid.ts
@@ -36,7 +36,7 @@ export const handler = async (req: NextApiRequest, res: NextApiResponse) => {
         case 'GET':
           return handleGET(res, setup);
         default:
-          res.setHeader('Allow', ['GET']);
+          res.setHeader('Allow', 'GET');
           res.status(405).json({ data: null, error: { message: `Method ${method} Not Allowed` } });
       }
     }

--- a/pages/api/setup/[token]/connections/index.ts
+++ b/pages/api/setup/[token]/connections/index.ts
@@ -20,7 +20,7 @@ export const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       case 'DELETE':
         return handleDELETE(req, res, setup);
       default:
-        res.setHeader('Allow', ['GET', 'POST', 'PATCH', 'DELETE']);
+        res.setHeader('Allow', 'GET, POST, PATCH, DELETE');
         res.status(405).json({ data: null, error: { message: `Method ${method} Not Allowed` } });
     }
   }

--- a/pages/api/setup/[token]/directory-sync/[directoryId]/index.ts
+++ b/pages/api/setup/[token]/directory-sync/[directoryId]/index.ts
@@ -13,7 +13,7 @@ export const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       case 'PUT':
         return handlePUT(req, res);
       default:
-        res.setHeader('Allow', ['PUT']);
+        res.setHeader('Allow', 'PUT');
         res.status(405).json({ data: null, error: { message: `Method ${method} Not Allowed` } });
     }
   }

--- a/pages/api/setup/[token]/directory-sync/index.ts
+++ b/pages/api/setup/[token]/directory-sync/index.ts
@@ -14,7 +14,7 @@ export const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       case 'POST':
         return handlePOST(req, res, setup);
       default:
-        res.setHeader('Allow', ['POST']);
+        res.setHeader('Allow', 'POST');
         res.status(405).json({ data: null, error: { message: `Method ${method} Not Allowed` } });
     }
   }

--- a/pages/api/setup/[token]/index.ts
+++ b/pages/api/setup/[token]/index.ts
@@ -8,7 +8,7 @@ export const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     case 'GET':
       return handleGET(req, res);
     default:
-      res.setHeader('Allow', ['GET']);
+      res.setHeader('Allow', 'GET');
       res.status(405).json({ data: null, error: { message: `Method ${method} Not Allowed` } });
   }
 };

--- a/pages/api/v1/directory-sync/[directoryId].ts
+++ b/pages/api/v1/directory-sync/[directoryId].ts
@@ -8,7 +8,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     case 'GET':
       return handleGET(req, res);
     default:
-      res.setHeader('Allow', ['GET']);
+      res.setHeader('Allow', 'GET');
       res.status(405).json({ data: null, error: { message: `Method ${method} Not Allowed` } });
   }
 }

--- a/pages/api/v1/directory-sync/groups/[groupId].ts
+++ b/pages/api/v1/directory-sync/groups/[groupId].ts
@@ -8,7 +8,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     case 'GET':
       return handleGET(req, res);
     default:
-      res.setHeader('Allow', ['GET']);
+      res.setHeader('Allow', 'GET');
       res.status(405).json({ data: null, error: { message: `Method ${method} Not Allowed` } });
   }
 }

--- a/pages/api/v1/directory-sync/groups/index.ts
+++ b/pages/api/v1/directory-sync/groups/index.ts
@@ -8,7 +8,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     case 'GET':
       return handleGET(req, res);
     default:
-      res.setHeader('Allow', ['GET']);
+      res.setHeader('Allow', 'GET');
       res.status(405).json({ data: null, error: { message: `Method ${method} Not Allowed` } });
   }
 }

--- a/pages/api/v1/directory-sync/index.ts
+++ b/pages/api/v1/directory-sync/index.ts
@@ -10,7 +10,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     case 'POST':
       return handlePOST(req, res);
     default:
-      res.setHeader('Allow', ['GET']);
+      res.setHeader('Allow', 'GET, POST');
       res.status(405).json({ data: null, error: { message: `Method ${method} Not Allowed` } });
   }
 }

--- a/pages/api/v1/directory-sync/users/[userId].ts
+++ b/pages/api/v1/directory-sync/users/[userId].ts
@@ -8,7 +8,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     case 'GET':
       return handleGET(req, res);
     default:
-      res.setHeader('Allow', ['GET']);
+      res.setHeader('Allow', 'GET');
       res.status(405).json({ data: null, error: { message: `Method ${method} Not Allowed` } });
   }
 }

--- a/pages/api/v1/directory-sync/users/index.ts
+++ b/pages/api/v1/directory-sync/users/index.ts
@@ -8,7 +8,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     case 'GET':
       return handleGET(req, res);
     default:
-      res.setHeader('Allow', ['GET']);
+      res.setHeader('Allow', 'GET');
       res.status(405).json({ data: null, error: { message: `Method ${method} Not Allowed` } });
   }
 }


### PR DESCRIPTION
## What does this PR do?

Prevent sending multiple `Allow` headers in the response. The standard approach is to set a comma separated string https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Allow. 

https://github.com/boxyhq/jackson/pull/733#discussion_r1041819699

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code and corrected any misspellings
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
