### PR TITLE
fix: display toast and adjust the width of the content

### DIFF
--- a/ee/federated-saml/pages/metadata.tsx
+++ b/ee/federated-saml/pages/metadata.tsx
@@ -14,9 +14,9 @@ const Metadata = ({ metadata }: { metadata: Metadata }) => {
   return (
     <LicenseRequired>
       <Toaster />
-      <div className='my-10 mx-5 flex justify-center'>
-        <div className='rounded border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800'>
-          <h2 className='mb-5 mt-5 font-bold text-gray-700 md:text-xl'>{t('saml_federation_app_info')}</h2>
+      <div className='mt-10 flex w-full justify-center px-5'>
+        <div className='w-full rounded border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800 md:w-1/2'>
+          <h2 className='mb-5 font-bold text-gray-700 md:text-xl'>{t('saml_federation_app_info')}</h2>
           <div className='flex flex-col'>
             <div className='space-y-3'>
               <p className='text-sm leading-6 text-gray-800'>{t('saml_federation_app_info_details')}</p>

--- a/pages/well-known/saml-configuration.tsx
+++ b/pages/well-known/saml-configuration.tsx
@@ -5,76 +5,80 @@ import { useTranslation } from 'next-i18next';
 import jackson from '@lib/jackson';
 import { InputWithCopyButton } from '@components/ClipboardButton';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import { Toaster } from '@components/Toaster';
 
 const SPConfig: NextPage<InferGetStaticPropsType<typeof getServerSideProps>> = ({ config }) => {
   const { t } = useTranslation('common');
 
   return (
-    <div className='mt-10 flex w-full justify-center'>
-      <div className='w-1/2 rounded border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800'>
-        <div className='flex flex-col space-y-3'>
-          <h2 className='font-bold text-gray-700 md:text-xl'>{t('sp_saml_config_title')}</h2>
-          <p className='text-sm leading-6 text-gray-800'>{t('sp_saml_config_description')}</p>
-          <p className='text-sm leading-6 text-gray-600'>
-            Refer to our&nbsp;
-            <a
-              href='https://boxyhq.com/docs/jackson/sso-providers'
-              target='_blank'
-              rel='noreferrer'
-              className='underline underline-offset-4'>
-              guides
-            </a>
-            &nbsp;for provider specific instructions.
-          </p>
-        </div>
-        <div className='mt-6 flex flex-col gap-6'>
-          <div className='form-control w-full'>
-            <InputWithCopyButton text={config.acsUrl} label={t('sp_acs_url')} />
+    <>
+      <Toaster />
+      <div className='mt-10 flex w-full justify-center px-5'>
+        <div className='w-full rounded border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800 md:w-1/2'>
+          <div className='flex flex-col space-y-3'>
+            <h2 className='font-bold text-gray-700 md:text-xl'>{t('sp_saml_config_title')}</h2>
+            <p className='text-sm leading-6 text-gray-800'>{t('sp_saml_config_description')}</p>
+            <p className='text-sm leading-6 text-gray-600'>
+              Refer to our&nbsp;
+              <a
+                href='https://boxyhq.com/docs/jackson/sso-providers'
+                target='_blank'
+                rel='noreferrer'
+                className='underline underline-offset-4'>
+                guides
+              </a>
+              &nbsp;for provider specific instructions.
+            </p>
           </div>
-          <div className='form-control w-full'>
-            <InputWithCopyButton text={config.entityId} label={t('sp_entity_id')} />
-          </div>
-          <div className='form-control w-full'>
-            <div className='flex flex-col'>
-              <label className='mb-2 block text-sm font-medium text-gray-900 dark:text-gray-300'>
-                {t('response')}
-              </label>
-              <p className='text-sm'>{config.response}</p>
+          <div className='mt-6 flex flex-col gap-6'>
+            <div className='form-control w-full'>
+              <InputWithCopyButton text={config.acsUrl} label={t('sp_acs_url')} />
             </div>
-          </div>
-          <div className='form-control w-full'>
-            <div className='flex flex-col'>
-              <label className='mb-2 block text-sm font-medium text-gray-900 dark:text-gray-300'>
-                {t('assertion_signature')}
-              </label>
-              <p className='text-sm'>{config.assertionSignature}</p>
+            <div className='form-control w-full'>
+              <InputWithCopyButton text={config.entityId} label={t('sp_entity_id')} />
             </div>
-          </div>
-          <div className='form-control w-full'>
-            <div className='flex flex-col'>
-              <label className='mb-2 block text-sm font-medium text-gray-900 dark:text-gray-300'>
-                {t('signature_algorithm')}
-              </label>
-              <p className='text-sm'>{config.signatureAlgorithm}</p>
+            <div className='form-control w-full'>
+              <div className='flex flex-col'>
+                <label className='mb-2 block text-sm font-medium text-gray-900 dark:text-gray-300'>
+                  {t('response')}
+                </label>
+                <p className='text-sm'>{config.response}</p>
+              </div>
             </div>
-          </div>
-          <div className='form-control w-full'>
-            <div className='flex flex-col'>
-              <label className='mb-2 block text-sm font-medium text-gray-900 dark:text-gray-300'>
-                {t('assertion_encryption')}
-              </label>
-              <p className='text-sm'>
-                If you want to encrypt the assertion, you can&nbsp;
-                <Link href='/.well-known/saml.cer' className='underline underline-offset-4' target='_blank'>
-                  download our public certificate.
-                </Link>
-                &nbsp;Otherwise select the Unencrypted option.
-              </p>
+            <div className='form-control w-full'>
+              <div className='flex flex-col'>
+                <label className='mb-2 block text-sm font-medium text-gray-900 dark:text-gray-300'>
+                  {t('assertion_signature')}
+                </label>
+                <p className='text-sm'>{config.assertionSignature}</p>
+              </div>
+            </div>
+            <div className='form-control w-full'>
+              <div className='flex flex-col'>
+                <label className='mb-2 block text-sm font-medium text-gray-900 dark:text-gray-300'>
+                  {t('signature_algorithm')}
+                </label>
+                <p className='text-sm'>{config.signatureAlgorithm}</p>
+              </div>
+            </div>
+            <div className='form-control w-full'>
+              <div className='flex flex-col'>
+                <label className='mb-2 block text-sm font-medium text-gray-900 dark:text-gray-300'>
+                  {t('assertion_encryption')}
+                </label>
+                <p className='text-sm'>
+                  If you want to encrypt the assertion, you can&nbsp;
+                  <Link href='/.well-known/saml.cer' className='underline underline-offset-4' target='_blank'>
+                    download our public certificate.
+                  </Link>
+                  &nbsp;Otherwise select the Unencrypted option.
+                </p>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## What does this PR do?

- Display the toast message after the content is copied to the clipboard
- Adjust the width of the content for SP and IdP configuration

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Existing unit tests

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code and corrected any misspellings
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
