### PR TITLE
Fix the Directory Sync operations

### DIFF
--- a/npm/src/directory-sync/types.ts
+++ b/npm/src/directory-sync/types.ts
@@ -120,3 +120,19 @@ export type PaginationParams = {
   pageOffset?: number;
   pageLimit?: number;
 };
+
+export type UserPatchOperation = {
+  op: 'replace';
+  path?: string;
+  value:
+    | boolean
+    | {
+        active: boolean;
+      }
+    | {
+        'name.givenName': string;
+      }
+    | {
+        'name.familyName': string;
+      };
+};

--- a/npm/src/directory-sync/utils.ts
+++ b/npm/src/directory-sync/utils.ts
@@ -143,7 +143,7 @@ const parseUserPatchRequest = (operation: UserPatchOperation) => {
   const { value, path } = operation;
 
   const attributes: Partial<User> = {};
-  const customAttributes = {};
+  const rawAttributes = {};
 
   const attributesMap = {
     active: 'active',
@@ -155,10 +155,10 @@ const parseUserPatchRequest = (operation: UserPatchOperation) => {
   // For example { path: "active", value: true }
   if (path) {
     if (path in attributesMap) {
-      attributes[path] = value;
-    } else {
-      customAttributes[path] = value;
+      attributes[attributesMap[path]] = value;
     }
+
+    rawAttributes[path] = value;
   }
 
   // If there is no path, then the value can be an object with multiple attributes
@@ -167,17 +167,41 @@ const parseUserPatchRequest = (operation: UserPatchOperation) => {
     for (const attribute of Object.keys(value)) {
       if (attribute in attributesMap) {
         attributes[attributesMap[attribute]] = value[attribute];
-      } else {
-        customAttributes[attribute] = value[attribute];
       }
+
+      rawAttributes[attribute] = value[attribute];
     }
   }
 
   return {
     attributes,
-    customAttributes,
+    rawAttributes,
   };
 };
+
+// function dotToObject(data) {
+//   function index(parent, key, value) {
+//     const [mainKey, ...children] = key.split('.');
+//     parent[mainKey] = parent[mainKey] || {};
+
+//     if (children.length === 1) {
+//       parent[mainKey][children[0]] = value;
+//     } else {
+//       index(parent[mainKey], children.join('.'), value);
+//     }
+//   }
+
+//   const result = Object.entries(data).reduce((acc, [key, value]) => {
+//     if (key.includes('.')) {
+//       index(acc, key, value);
+//     } else {
+//       acc[key] = value;
+//     }
+
+//     return acc;
+//   }, {});
+//   return result;
+// }
 
 export {
   parseGroupOperations,

--- a/npm/src/directory-sync/utils.ts
+++ b/npm/src/directory-sync/utils.ts
@@ -6,7 +6,7 @@ import type {
   Group,
   User,
 } from '../typings';
-import { DirectorySyncProviders } from '../typings';
+import { DirectorySyncProviders, UserPatchOperation } from '../typings';
 import { transformUser, transformGroup, transformUserGroup } from './transform';
 import crypto from 'crypto';
 
@@ -71,46 +71,6 @@ const toGroupMembers = (users: { user_id: string }[]): DirectorySyncGroupMember[
   return users.map((user) => ({
     value: user.user_id,
   }));
-};
-
-export const parseUserOperations = (operations: {
-  op: 'replace';
-  value: any;
-}): {
-  action: 'updateUser' | 'unknown';
-  raw: any;
-  attributes: Partial<User>;
-} => {
-  const { op, value } = operations[0];
-
-  const attributes: Partial<User> = {};
-
-  // Update the user
-  if (op === 'replace') {
-    if ('active' in value) {
-      attributes['active'] = value.active;
-    }
-
-    if ('name.givenName' in value) {
-      attributes['first_name'] = value['name.givenName'];
-    }
-
-    if ('name.familyName' in value) {
-      attributes['last_name'] = value['name.familyName'];
-    }
-
-    return {
-      action: 'updateUser',
-      raw: value,
-      attributes,
-    };
-  }
-
-  return {
-    action: 'unknown',
-    raw: value,
-    attributes,
-  };
 };
 
 // List of directory sync providers
@@ -178,6 +138,47 @@ const createSignatureString = async (secret: string, event: DirectorySyncEvent) 
   return `t=${timestamp},s=${signature}`;
 };
 
+// Parse the PATCH request body and return the user attributes (both standard and custom)
+const parseUserPatchRequest = (operation: UserPatchOperation) => {
+  const { value, path } = operation;
+
+  const attributes: Partial<User> = {};
+  const customAttributes = {};
+
+  const attributesMap = {
+    active: 'active',
+    'name.givenName': 'first_name',
+    'name.familyName': 'last_name',
+  };
+
+  // If there is a path, then the value is the value
+  // For example { path: "active", value: true }
+  if (path) {
+    if (path in attributesMap) {
+      attributes[path] = value;
+    } else {
+      customAttributes[path] = value;
+    }
+  }
+
+  // If there is no path, then the value can be an object with multiple attributes
+  // For example { value: { active: true, "name.familyName": "John" } }
+  else if (typeof value === 'object') {
+    for (const attribute of Object.keys(value)) {
+      if (attribute in attributesMap) {
+        attributes[attributesMap[attribute]] = value[attribute];
+      } else {
+        customAttributes[attribute] = value[attribute];
+      }
+    }
+  }
+
+  return {
+    attributes,
+    customAttributes,
+  };
+};
+
 export {
   parseGroupOperations,
   toGroupMembers,
@@ -185,4 +186,5 @@ export {
   transformEventPayload,
   createHeader,
   createSignatureString,
+  parseUserPatchRequest,
 };

--- a/npm/src/directory-sync/utils.ts
+++ b/npm/src/directory-sync/utils.ts
@@ -179,30 +179,6 @@ const parseUserPatchRequest = (operation: UserPatchOperation) => {
   };
 };
 
-// function dotToObject(data) {
-//   function index(parent, key, value) {
-//     const [mainKey, ...children] = key.split('.');
-//     parent[mainKey] = parent[mainKey] || {};
-
-//     if (children.length === 1) {
-//       parent[mainKey][children[0]] = value;
-//     } else {
-//       index(parent[mainKey], children.join('.'), value);
-//     }
-//   }
-
-//   const result = Object.entries(data).reduce((acc, [key, value]) => {
-//     if (key.includes('.')) {
-//       index(acc, key, value);
-//     } else {
-//       acc[key] = value;
-//     }
-
-//     return acc;
-//   }, {});
-//   return result;
-// }
-
 export {
   parseGroupOperations,
   toGroupMembers,

--- a/npm/test/dsync/data/user-requests.ts
+++ b/npm/test/dsync/data/user-requests.ts
@@ -106,6 +106,41 @@ const requests = {
       query: {},
     };
   },
+
+  // Multi-valued properties
+  multiValuedProperties: (directory: Directory, userId: string): DirectorySyncRequest => {
+    return {
+      method: 'PATCH',
+      body: {
+        Operations: [
+          {
+            op: 'replace',
+            path: 'name.givenName',
+            value: 'David',
+          },
+          {
+            op: 'replace',
+            path: 'name.familyName',
+            value: 'Jones',
+          },
+          {
+            op: 'add',
+            path: 'companyName',
+            value: 'BoxyHQ',
+          },
+          {
+            op: 'replace',
+            value: { active: false },
+          },
+        ],
+      },
+      directoryId: directory.id,
+      resourceType: 'users',
+      resourceId: userId,
+      apiSecret: directory.scim.secret,
+      query: {},
+    };
+  },
 };
 
 export default requests;

--- a/npm/test/dsync/users.test.ts
+++ b/npm/test/dsync/users.test.ts
@@ -115,6 +115,21 @@ tap.test('Directory users / ', async (t) => {
     t.end();
   });
 
+  t.test('should be able to update the user with multi-valued properties', async (t) => {
+    const { status, data } = await directorySync.requests.handle(
+      requests.multiValuedProperties(directory, createdUser.id)
+    );
+
+    console.log({ data });
+
+    t.ok(data);
+    t.equal(status, 200);
+    t.equal(data.active, false);
+    t.equal(data.companyName, 'BoxyHQ');
+
+    t.end();
+  });
+
   t.test('Should be able to fetch all users', async (t) => {
     const { status, data } = await directorySync.requests.handle(requests.getAll(directory));
 

--- a/npm/test/dsync/users.test.ts
+++ b/npm/test/dsync/users.test.ts
@@ -120,8 +120,6 @@ tap.test('Directory users / ', async (t) => {
       requests.multiValuedProperties(directory, createdUser.id)
     );
 
-    console.log({ data });
-
     t.ok(data);
     t.equal(status, 200);
     t.equal(data.active, false);


### PR DESCRIPTION
## What does this PR do?

This PR add support to handle multi-valued attributes in SCIM operations in a single PATCH request.

For example

```javascript
Operations: [
  {
    op: "replace",
    path: "name.givenName",
    value: "David",
  },
  {
    op: "replace",
    path: "name.familyName",
    value: "Jones",
  },
  {
    op: "add",
    path: "companyName",
    value: "BoxyHQ",
  },
  {
    op: "replace",
    value: { active: false },
  },
];
```

The above request will send an `user.updated` event with updated user payload.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Existing unit tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code and corrected any misspellings
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
