### PR TITLE
Jumpcloud fixes

### DIFF
--- a/npm/src/controller/connection/saml.ts
+++ b/npm/src/controller/connection/saml.ts
@@ -126,6 +126,8 @@ const saml = {
       value: idpMetadata.entityID,
     });
 
+    let exists: any[] = [];
+
     if (existing.length > 0) {
       for (let i = 0; i < existing.length; i++) {
         const samlConfig = existing[i];
@@ -133,19 +135,16 @@ const saml = {
           throw new JacksonError('EntityID already exists for different tenant/product');
         } else if (samlConfig.tenant !== tenant && samlConfig.product !== product) {
           throw new JacksonError('EntityID already exists for different tenant/product');
-        } else {
+        } else if (samlConfig.tenant === tenant && samlConfig.product !== product) {
           continue;
+        } else {
+          exists.push(samlConfig);
         }
       }
     }
 
-    const exists = await connectionStore.getByIndex({
-      name: IndexNames.EntityID,
-      value: record.clientID,
-    });
-
     if (exists.length > 0) {
-      connectionClientSecret = exists.clientSecret;
+      connectionClientSecret = exists[0].clientSecret;
     } else {
       connectionClientSecret = crypto.randomBytes(24).toString('hex');
     }

--- a/npm/src/controller/connection/saml.ts
+++ b/npm/src/controller/connection/saml.ts
@@ -139,7 +139,7 @@ const saml = {
       }
     }
 
-    let exists = await connectionStore.get(record.clientID);
+    const exists = await connectionStore.get(record.clientID);
 
     if (exists) {
       connectionClientSecret = exists.clientSecret;

--- a/npm/src/controller/connection/saml.ts
+++ b/npm/src/controller/connection/saml.ts
@@ -126,8 +126,6 @@ const saml = {
       value: idpMetadata.entityID,
     });
 
-    let exists: any[] = [];
-
     if (existing.length > 0) {
       for (let i = 0; i < existing.length; i++) {
         const samlConfig = existing[i];
@@ -135,16 +133,16 @@ const saml = {
           throw new JacksonError('EntityID already exists for different tenant/product');
         } else if (samlConfig.tenant !== tenant && samlConfig.product !== product) {
           throw new JacksonError('EntityID already exists for different tenant/product');
-        } else if (samlConfig.tenant === tenant && samlConfig.product !== product) {
-          continue;
         } else {
-          exists.push(samlConfig);
+          continue;
         }
       }
     }
 
-    if (exists.length > 0) {
-      connectionClientSecret = exists[0].clientSecret;
+    let exists = await connectionStore.get(record.clientID);
+
+    if (exists) {
+      connectionClientSecret = exists.clientSecret;
     } else {
       connectionClientSecret = crypto.randomBytes(24).toString('hex');
     }


### PR DESCRIPTION
It was needed to find connections with the same tenant, product & entityID.
So instead of using getByIndex which was not required using the get method to get the same

## What does this PR do?

Fixes the bug regarding ClientID with JumpCloud use case

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

JumpCloud Workflow
 - Add 2 SSO connections with the same tenant, product & entity id
 - Jackson should not create a new `connectionClientSecret`

- [x] Existing unit tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code and corrected any misspellings
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
