### PR TITLE
Add API to fetch dsync connections by product

### DIFF
--- a/npm/src/controller/utils.ts
+++ b/npm/src/controller/utils.ts
@@ -26,6 +26,7 @@ export enum IndexNames {
   Service = 'service',
   OIDCProviderClientID = 'OIDCProviderClientID',
   SSOClientID = 'SSOClientID',
+  Product = 'product',
 }
 
 // The namespace prefix for the database store

--- a/npm/src/directory-sync/non-scim/google/api.ts
+++ b/npm/src/directory-sync/non-scim/google/api.ts
@@ -45,7 +45,7 @@ export class GoogleProvider implements IDirectoryProvider {
   }
 
   async getDirectories() {
-    const { data: directories } = await this.directories.getByProvider({
+    const { data: directories } = await this.directories.filterBy({
       provider: 'google',
     });
 

--- a/npm/test/dsync/directories.test.ts
+++ b/npm/test/dsync/directories.test.ts
@@ -208,6 +208,7 @@ tap.test('directories.', async (t) => {
       t.strictSame(directoriesFetched?.length, 0);
     });
   });
+
   t.test('update()', async (t) => {
     let directory: Directory;
 
@@ -353,7 +354,7 @@ tap.test('directories.', async (t) => {
     });
 
     // Fetch all the directories of type google
-    const { data: googleDirectoryFetched } = await directorySync.directories.getByProvider({
+    const { data: googleDirectoryFetched } = await directorySync.directories.filterBy({
       provider: 'google',
     });
 
@@ -405,5 +406,27 @@ tap.test('directories.', async (t) => {
     t.match(directoryFetched?.google_access_token, 'access_token');
     t.match(directoryFetched?.google_refresh_token, 'refresh_token');
     t.match(directoryFetched?.google_domain, 'acme.com');
+  });
+
+  t.test('Fetch all connections for a product', async (t) => {
+    await directorySync.directories.create({
+      ...directoryPayload,
+      tenant: 'first-tenant',
+      product: 'a-new-product',
+    });
+
+    const { data: directories, error } = await directorySync.directories.filterBy({
+      product: 'a-new-product',
+    });
+
+    if (error) {
+      t.fail(error.message);
+      return;
+    }
+
+    t.ok(directories);
+    t.match(directories.length, 1);
+    t.match(directories[0].tenant, 'first-tenant');
+    t.match(directories[0].product, 'a-new-product');
   });
 });

--- a/pages/api/v1/directory-sync/products.ts
+++ b/pages/api/v1/directory-sync/products.ts
@@ -1,0 +1,45 @@
+import jackson from '@lib/jackson';
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { method } = req;
+
+  try {
+    switch (method) {
+      case 'GET':
+        return await handleGET(req, res);
+      default:
+        res.setHeader('Allow', 'GET');
+        res.status(405).json({ error: { message: `Method ${method} Not Allowed` } });
+    }
+  } catch (error: any) {
+    const { message, statusCode = 500 } = error;
+
+    return res.status(statusCode).json({ error: { message } });
+  }
+}
+
+// Get the connections filtered by the product
+const handleGET = async (req: NextApiRequest, res: NextApiResponse) => {
+  const { directorySyncController } = await jackson();
+
+  const { product, pageOffset, pageLimit, pageToken } = req.query as {
+    product: string;
+    pageOffset: string;
+    pageLimit: string;
+    pageToken?: string;
+  };
+
+  if (!product) {
+    throw new Error('Please provide a product');
+  }
+
+  const connections = await directorySyncController.directories.filterBy({
+    product,
+    pageOffset: parseInt(pageOffset),
+    pageLimit: parseInt(pageLimit),
+    pageToken,
+  });
+
+  return res.status(200).json(connections);
+};


### PR DESCRIPTION
## What does this PR do?

This PR adds an API to fetch dsync connections by product.

- Added secondary index `product` to the connections
- Added a new endpoint `/api/v1/directory-sync/products` to fetch connections by product

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Updated dependencies
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Existing unit tests
- [x] New unit tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code and corrected any misspellings
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
