### PR TITLE
chore: add logging to the healthcheck in case it fails

### DIFF
--- a/pages/api/health.ts
+++ b/pages/api/health.ts
@@ -16,6 +16,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       version: packageInfo.version,
     });
   } catch (err: any) {
+    console.error('HealthCheck failed', err);
     const { statusCode = 503 } = err;
     res.status(statusCode).json({});
   }


### PR DESCRIPTION
## What does this PR do?

This PR displays the error that the health check has on the server so we are not blind when we have configuration errors.

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How should this be tested?

In case of a misconfiguration error, e.g wrong DB_ENCRYPTION_KEY, the health check fails silently 

- [ ] Existing unit tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code and corrected any misspellings
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
