### PR TITLE
Tweak custom logo rendering

### DIFF
--- a/components/layouts/SetupLinkLayout.tsx
+++ b/components/layouts/SetupLinkLayout.tsx
@@ -1,7 +1,7 @@
+/* eslint-disable @next/next/no-img-element */
 import React from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
-import Image from 'next/image';
 import { useRouter } from 'next/router';
 import InvalidSetupLinkAlert from '@components/setup-link/InvalidSetupLinkAlert';
 import Loading from '@components/Loading';
@@ -44,7 +44,7 @@ export const SetupLinkLayout = ({ children }: { children: React.ReactNode }) => 
             <div className='flex flex-shrink-0 items-center gap-4'>
               <Link href={`/setup/${token}`}>
                 {setupLink?.logoUrl && (
-                  <Image src={setupLink.logoUrl} alt={setupLink.companyName || ''} width={40} height={40} />
+                  <img src={setupLink.logoUrl} alt={setupLink.companyName || ''} className='max-h-10' />
                 )}
               </Link>
               <span className='text-xl font-bold tracking-wide text-gray-900'>{title}</span>

--- a/pages/idp/select.tsx
+++ b/pages/idp/select.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @next/next/no-img-element */
 import { useEffect, useRef, useState } from 'react';
 import getRawBody from 'raw-body';
 import { useRouter } from 'next/router';
@@ -8,7 +9,6 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
 import jackson from '@lib/jackson';
 import Head from 'next/head';
 import { hexToOklch } from '@lib/color';
-import Image from 'next/image';
 import { PoweredBy } from '@components/PoweredBy';
 import { getPortalBranding, getProductBranding } from '@ee/branding/utils';
 import { boxyhqHosted } from '@lib/env';
@@ -47,7 +47,7 @@ export default function ChooseIdPConnection({
 
         {branding?.logoUrl && (
           <div className='flex justify-center'>
-            <Image src={branding.logoUrl} alt={branding.companyName} width={50} height={50} />
+            <img src={branding.logoUrl} alt={branding.companyName} className='max-h-12' />
           </div>
         )}
 


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Use <img> without width/height attributes for custom logo rendering. This should respect the intrinsic image dimensions. Also a max-height is set to cap the image size.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Updated dependencies
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Test out idp selection and setup link pages with a custom brand logo.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code and corrected any misspellings
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
