### PR TITLE
Handle group patches where value is a string

### DIFF
--- a/npm/src/directory-sync/scim/utils.ts
+++ b/npm/src/directory-sync/scim/utils.ts
@@ -21,7 +21,7 @@ const parseUserRoles = (roles: string | string[]) => {
 export const parseGroupOperation = (operation: GroupPatchOperation) => {
   const { op, path, value } = operation;
 
-  if (path === 'members') {
+  if (path === 'members' && typeof value == 'object') {
     if (op === 'add') {
       return {
         action: 'addGroupMember',
@@ -47,11 +47,18 @@ export const parseGroupOperation = (operation: GroupPatchOperation) => {
   }
 
   // Update group name
-  if (op === 'replace' && 'displayName' in value) {
-    return {
-      action: 'updateGroupName',
-      displayName: value.displayName,
-    };
+  if (op === 'replace') {
+    if (path == 'displayName' && typeof value == 'string') {
+      return {
+        action: 'updateGroupName',
+        displayName: value,
+      };
+    } else if (typeof value == 'object' && 'displayName' in value) {
+      return {
+        action: 'updateGroupName',
+        displayName: value.displayName,
+      };
+    }
   }
 
   return {

--- a/npm/src/directory-sync/types.ts
+++ b/npm/src/directory-sync/types.ts
@@ -164,10 +164,12 @@ export type UserPatchOperation = {
 export type GroupPatchOperation = {
   op: 'add' | 'remove' | 'replace';
   path?: 'members' | 'displayName';
-  value: {
-    value: string;
-    display?: string;
-  }[];
+  value:
+    | string
+    | {
+        value: string;
+        display?: string;
+      }[];
 };
 
 export type GroupMembership = {


### PR DESCRIPTION
## What does this PR do?

I discovered that an error was thrown when I changed the name of a group in Azure and tried to provision the group:

```
 ⨯ npm/src/directory-sync/scim/utils.ts (50:26) @ parseGroupOperation
 ⨯ TypeError: Cannot use 'in' operator to search for 'displayName' in PreciselyQA/21/Team/FFS2
    at parseGroupOperation (webpack-internal:///(api)/./npm/src/directory-sync/scim/utils.ts:57:43)
    at DirectoryGroups.patch (webpack-internal:///(api)/./npm/src/directory-sync/scim/DirectoryGroups.ts:98:90)
    at DirectoryGroups.handleRequest (webpack-internal:///(api)/./npm/src/directory-sync/scim/DirectoryGroups.ts:262:39)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async RequestHandler.handle (webpack-internal:///(api)/./npm/src/directory-sync/request.ts:16:20)
    at async handler (webpack-internal:///(api)/./pages/api/scim/v2.0/[...directory].ts:29:30)
    at async K (/home/andreas/jackson/node_modules/next/dist/compiled/next-server/pages-api.runtime.dev.js:21:2946)
    at async U.render (/home/andreas/jackson/node_modules/next/dist/compiled/next-server/pages-api.runtime.dev.js:21:3827)
    at async DevServer.runApi (/home/andreas/jackson/node_modules/next/dist/server/next-server.js:554:9)
    at async NextNodeServer.handleCatchallRenderRequest (/home/andreas/jackson/node_modules/next/dist/server/next-server.js:266:37)
    at async DevServer.handleRequestImpl (/home/andreas/jackson/node_modules/next/dist/server/base-server.js:791:17)
    at async /home/andreas/jackson/node_modules/next/dist/server/dev/next-dev-server.js:331:20
    at async Span.traceAsyncFn (/home/andreas/jackson/node_modules/next/dist/trace/trace.js:151:20)
    at async DevServer.handleRequest (/home/andreas/jackson/node_modules/next/dist/server/dev/next-dev-server.js:328:24)
    at async invokeRender (/home/andreas/jackson/node_modules/next/dist/server/lib/router-server.js:174:21) {
  page: '/api/scim/v2.0/[...directory]'
}
  48 |
  49 |   // Update group name
> 50 |   if (op === 'replace' && 'displayName' in value) {
     |                          ^
  51 |     return {
  52 |       action: 'updateGroupName',
  53 |       displayName: value.displayName,
```

This adds support for the patch operation

```json
{
  "op": "replace",
  "path": "displayName",
  "value": "new-name"
}
```

You may want to take a look at https://github.com/thomaspoignant/scim-patch for handling the patching, it's very capable.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. Provision a group from Azure
2. Change the name of the group in Azure
3. Provision the group again

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code and corrected any misspellings
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
