### PR TITLE
Relay OpenId params to OIDC Identity providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,3 +111,6 @@ ENTERPRISE_ORY_PROJECT_ID=
 
 # Uncomment below if you wish to opt-out of sending `profile` scope in OIDC Provider Authorization Request
 #OPENID_REQUEST_PROFILE_SCOPE=false
+
+# Uncomment below if you wish to forward the OpenID params (https://openid.net/specs/openid-connect-core-1_0-errata2.html#AuthRequest) to the OpenID IdP
+#OPENID_REQUEST_FORWARD_PARAMS=true

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -72,6 +72,7 @@ const jacksonOptions: JacksonOption = {
       public: process.env.OPENID_RSA_PUBLIC_KEY || '',
     },
     requestProfileScope: process.env.OPENID_REQUEST_PROFILE_SCOPE === 'false' ? false : true,
+    forwardOIDCParams: process.env.OPENID_REQUEST_FORWARD_PARAMS === 'true' ? true : false,
   },
   certs: {
     publicKey: process.env.PUBLIC_KEY || '',

--- a/npm/src/controller/oauth.ts
+++ b/npm/src/controller/oauth.ts
@@ -77,6 +77,10 @@ export class OAuthController implements IOAuthController {
 
   public async authorize(body: OAuthReq): Promise<{ redirect_url?: string; authorize_form?: string }> {
     const {
+      tenant,
+      product,
+      access_type,
+      resource,
       response_type = 'code',
       client_id,
       redirect_uri,
@@ -88,6 +92,7 @@ export class OAuthController implements IOAuthController {
       idp_hint,
       forceAuthn = 'false',
       login_hint,
+      ...oidcParams // Rest of the params will be assumed as OIDC params and will be forwarded to the IdP
     } = body;
 
     let requestedTenant;
@@ -99,11 +104,6 @@ export class OAuthController implements IOAuthController {
     let fedApp: IdentityFederationApp | undefined;
 
     try {
-      const tenant = 'tenant' in body ? body.tenant : undefined;
-      const product = 'product' in body ? body.product : undefined;
-      const access_type = 'access_type' in body ? body.access_type : undefined;
-      const resource = 'resource' in body ? body.resource : undefined;
-
       requestedTenant = tenant;
       requestedProduct = product;
 
@@ -418,6 +418,7 @@ export class OAuthController implements IOAuthController {
           state: relayState,
           nonce: oidcNonce,
           login_hint,
+          ...oidcParams,
         });
       } catch (err: unknown) {
         const error_description = (err as errors.OPError)?.error || getErrorMessage(err);

--- a/npm/src/controller/oauth.ts
+++ b/npm/src/controller/oauth.ts
@@ -143,6 +143,9 @@ export class OAuthController implements IOAuthController {
         }
         if (!sp && resource) {
           sp = getEncodedTenantProduct(resource);
+          if (sp === null) {
+            oidcParams.resource = resource;
+          }
         }
         if (!sp && requestedScopes) {
           const encodedParams = requestedScopes.find((scope) => scope.includes('=') && scope.includes('&')); // for now assume only one encoded param i.e. for tenant/product

--- a/npm/src/controller/oauth.ts
+++ b/npm/src/controller/oauth.ts
@@ -409,6 +409,7 @@ export class OAuthController implements IOAuthController {
         const standardScopes = this.opts.openid?.requestProfileScope
           ? ['openid', 'email', 'profile']
           : ['openid', 'email'];
+        const authzParams = this.opts.openid?.forwardOIDCParams ? oidcParams : {};
         ssoUrl = oidcClient.authorizationUrl({
           scope: [...requestedScopes, ...standardScopes]
             .filter((value, index, self) => self.indexOf(value) === index) // filter out duplicates
@@ -418,7 +419,7 @@ export class OAuthController implements IOAuthController {
           state: relayState,
           nonce: oidcNonce,
           login_hint,
-          ...oidcParams,
+          ...authzParams,
         });
       } catch (err: unknown) {
         const error_description = (err as errors.OPError)?.error || getErrorMessage(err);

--- a/npm/src/controller/oauth.ts
+++ b/npm/src/controller/oauth.ts
@@ -412,7 +412,7 @@ export class OAuthController implements IOAuthController {
         const standardScopes = this.opts.openid?.requestProfileScope
           ? ['openid', 'email', 'profile']
           : ['openid', 'email'];
-        const authzParams = this.opts.openid?.forwardOIDCParams ? oidcParams : {};
+        const paramsToForward = this.opts.openid?.forwardOIDCParams ? oidcParams : {};
         ssoUrl = oidcClient.authorizationUrl({
           scope: [...requestedScopes, ...standardScopes]
             .filter((value, index, self) => self.indexOf(value) === index) // filter out duplicates
@@ -422,7 +422,7 @@ export class OAuthController implements IOAuthController {
           state: relayState,
           nonce: oidcNonce,
           login_hint,
-          ...authzParams,
+          ...paramsToForward,
         });
       } catch (err: unknown) {
         const error_description = (err as errors.OPError)?.error || getErrorMessage(err);

--- a/npm/src/index.ts
+++ b/npm/src/index.ts
@@ -51,6 +51,7 @@ const defaultOpts = (opts: JacksonOption): JacksonOption => {
   newOpts.openid = newOpts.openid || {};
   newOpts.openid.jwsAlg = newOpts.openid.jwsAlg || 'RS256';
   newOpts.openid.requestProfileScope = newOpts.openid?.requestProfileScope ?? true;
+  newOpts.openid.forwardOIDCParams = newOpts.openid?.forwardOIDCParams ?? false;
 
   newOpts.boxyhqLicenseKey = newOpts.boxyhqLicenseKey || undefined;
 

--- a/npm/src/typings.ts
+++ b/npm/src/typings.ts
@@ -257,6 +257,7 @@ export interface OAuthReqBody {
   idp_hint?: string;
   forceAuthn?: string;
   login_hint?: string;
+  [key: string]: unknown;
 }
 
 export interface OAuthReqBodyWithClientId extends OAuthReqBody {

--- a/npm/src/typings.ts
+++ b/npm/src/typings.ts
@@ -439,6 +439,7 @@ export interface JacksonOption {
       public: string;
     };
     requestProfileScope?: boolean; // defaults to true
+    forwardOIDCParams?: boolean; // defaults to false
   };
   certs?: {
     publicKey: string;

--- a/npm/src/typings.ts
+++ b/npm/src/typings.ts
@@ -261,42 +261,41 @@ export interface OAuthReqBody {
 
 export interface OAuthReqBodyWithClientId extends OAuthReqBody {
   client_id: string;
+  tenant?: undefined;
+  product?: undefined;
+  access_type?: undefined;
+  resource?: undefined;
 }
 
 export interface OAuthReqBodyWithTenantProduct extends OAuthReqBody {
   client_id: 'dummy';
   tenant: string;
   product: string;
+  access_type?: undefined;
+  resource?: undefined;
 }
 
 export interface OAuthReqBodyWithAccessType extends OAuthReqBody {
   client_id: 'dummy';
   access_type: string;
+  tenant?: undefined;
+  product?: undefined;
+  resource?: undefined;
 }
 
 export interface OAuthReqBodyWithResource extends OAuthReqBody {
   client_id: 'dummy';
   resource: string;
+  tenant?: undefined;
+  product?: undefined;
+  access_type?: undefined;
 }
 
-type FillKeys<T> = (
-  (T extends T ? keyof T : never) extends infer AllKeys
-    ? T extends T
-      ? { [K in keyof T]: T[K] } & {
-          [K in AllKeys extends keyof T ? never : AllKeys extends string ? AllKeys : never]?: undefined;
-        }
-      : never
-    : never
-) extends infer U
-  ? { [K in keyof U]: U[K] }
-  : never;
-
-export type OAuthReq = FillKeys<
+export type OAuthReq =
   | OAuthReqBodyWithClientId
   | OAuthReqBodyWithTenantProduct
   | OAuthReqBodyWithAccessType
-  | OAuthReqBodyWithResource
->;
+  | OAuthReqBodyWithResource;
 
 export interface SAMLResponsePayload {
   SAMLResponse: string;

--- a/npm/src/typings.ts
+++ b/npm/src/typings.ts
@@ -279,11 +279,24 @@ export interface OAuthReqBodyWithResource extends OAuthReqBody {
   resource: string;
 }
 
-export type OAuthReq =
+type FillKeys<T> = (
+  (T extends T ? keyof T : never) extends infer AllKeys
+    ? T extends T
+      ? { [K in keyof T]: T[K] } & {
+          [K in AllKeys extends keyof T ? never : AllKeys extends string ? AllKeys : never]?: undefined;
+        }
+      : never
+    : never
+) extends infer U
+  ? { [K in keyof U]: U[K] }
+  : never;
+
+export type OAuthReq = FillKeys<
   | OAuthReqBodyWithClientId
   | OAuthReqBodyWithTenantProduct
   | OAuthReqBodyWithAccessType
-  | OAuthReqBodyWithResource;
+  | OAuthReqBodyWithResource
+>;
 
 export interface SAMLResponsePayload {
   SAMLResponse: string;

--- a/npm/test/sso/oidc_idp_oauth.test.ts
+++ b/npm/test/sso/oidc_idp_oauth.test.ts
@@ -77,6 +77,41 @@ tap.test('[OIDCProvider]', async (t) => {
     }
   );
 
+  t.test(
+    '[authorize] Should not forward openid params if openid.forwardOIDCParams is set to false',
+    async (t) => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      oauthController.opts.openid.forwardOIDCParams = false;
+      const response = (await oauthController.authorize(<OAuthReq>{
+        ...authz_request_oidc_provider,
+        scope: 'openid email profile',
+        prompt: 'none',
+      })) as {
+        redirect_url: string;
+      };
+      const params = new URLSearchParams(new URL(response.redirect_url!).search);
+      t.ok('redirect_url' in response, 'got the Idp authorize URL');
+      t.match(params.has('prompt'), false, 'prompt param should be absent');
+    }
+  );
+
+  t.test('[authorize] Should forward openid params if openid.forwardOIDCParams is set to true', async (t) => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    oauthController.opts.openid.forwardOIDCParams = true;
+    const response = (await oauthController.authorize(<OAuthReq>{
+      ...authz_request_oidc_provider,
+      scope: 'openid email profile',
+      prompt: 'none',
+    })) as {
+      redirect_url: string;
+    };
+    const params = new URLSearchParams(new URL(response.redirect_url!).search);
+    t.ok('redirect_url' in response, 'got the Idp authorize URL');
+    t.match(params.has('prompt'), true, 'prompt param should be present');
+  });
+
   t.test('[authorize] Should return error if `oidcPath` is not set', async (t) => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Jackson will be able to forward standard OIDC params to the IdP on the back of `openid.forwardOIDCParams` option ( `OPENID_REQUEST_FORWARD_PARAMS` env)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Updated dependencies
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Existing unit tests
- [x] Use an OIDC connection like Google and NextAuth example app. Set `OPENID_REQUEST_FORWARD_PARAMS` to true in .env.Add an OIDC param like `prompt` or `acr_values` to the authorization params setting in the provider. Use the network tab to inspect the request to the OIDC provider and ensure that the params are there in the request.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code and corrected any misspellings
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
