### PR TITLE
Include claims from id token in `profile.raw`

### DIFF
--- a/npm/src/controller/utils.ts
+++ b/npm/src/controller/utils.ts
@@ -263,7 +263,7 @@ export const extractOIDCUserProfile = async (tokenSet: TokenSet, oidcClient: Cli
   profile.claims.lastName = idTokenClaims.family_name ?? userinfo.family_name;
   profile.claims.roles = idTokenClaims.roles ?? (userinfo.roles as any);
   profile.claims.groups = idTokenClaims.groups ?? (userinfo.groups as any);
-  profile.claims.raw = userinfo;
+  profile.claims.raw = { ...idTokenClaims, ...userinfo };
 
   return profile;
 };


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This change fixes an issue where optional claims set inside the ID token would not be forwarded in the returned profile.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Updated dependencies
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Use admin portal SSO against an OIDC provider like Azure and set optional claims. Inspect the profile in NextAuth [sign-in callback](https://github.com/boxyhq/jackson/blob/main/pages/api/auth/%5B...nextauth%5D.ts#L148) to ensure the custom claim is set in the profile object.

- [ ] Existing unit tests

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code and corrected any misspellings
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
