### PR TITLE
Fix for bypassing allowed steps in Setup Links

### DIFF
--- a/pages/setup/[token]/sso-connection/new.tsx
+++ b/pages/setup/[token]/sso-connection/new.tsx
@@ -184,6 +184,7 @@ export async function getServerSideProps({ locale, query }: GetServerSidePropsCo
   const { idp, step, token } = query as { idp: string; step: string; token: string };
 
   // Validate IDP and step
+  let stepNumber;
   if (idp) {
     const provider = identityProviders.find((p) => p.id === idp);
     if (!provider) {
@@ -195,7 +196,8 @@ export async function getServerSideProps({ locale, query }: GetServerSidePropsCo
     }
 
     if (step) {
-      const stepNumber = parseInt(step);
+      stepNumber = parseInt(step, 10);
+
       if (isNaN(stepNumber) || stepNumber < 1 || stepNumber > provider.stepCount) {
         return {
           redirect: {
@@ -214,11 +216,11 @@ export async function getServerSideProps({ locale, query }: GetServerSidePropsCo
 
   let mdxSource: MDXRemoteSerializeResult<Record<string, unknown>> | null = null;
 
-  // Read the MDX file based on the idp and step
-  if (idp && step) {
+  // Read the MDX file based on the idp and stepNumber
+  if (idp && stepNumber) {
     try {
       const mdxDirectory = path.join(process.cwd(), `components/setup-link-instructions/${idp}`);
-      const source = fs.readFileSync(`${mdxDirectory}/${step}.mdx`, 'utf8');
+      const source = fs.readFileSync(`${mdxDirectory}/${stepNumber}.mdx`, 'utf8');
       mdxSource = await serialize(source, { mdxOptions: { remarkPlugins: [remarkGfm] } });
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (err: any) {


### PR DESCRIPTION
Use parsed step number to load the file to prevent bypass via non-strict parseInt

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Updated dependencies
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [ ] Existing unit tests

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code and corrected any misspellings
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
