### PR TITLE
fix: report descriptive error when SAML assertion is missing both id and email

### DIFF
--- a/npm/src/saml/lib.ts
+++ b/npm/src/saml/lib.ts
@@ -18,6 +18,10 @@ export const extractSAMLResponseAttributes = async (
     if (!attributes.claims.id && attributes.claims.email) {
       attributes.claims.id = crypto.createHash('sha256').update(attributes.claims.email).digest('hex');
     }
+
+    if (!attributes.claims.id) {
+      throw new Error('SAML assertion is missing both id (NameID) and email. Ensure the IdP is configured to send at least one of these attributes.');
+    }
   }
 
   // we'll send a ripemd160 hash of the id, this can be used in the case of email missing it can be used as the local part


### PR DESCRIPTION
## Summary

Adds an explicit validation check in `extractSAMLResponseAttributes` to throw a descriptive error when a SAML assertion contains neither a NameID (`id`) nor an `email` attribute, instead of letting it bubble up as a cryptic buffer error.

## Problem

When a SAML IdP sends an assertion without a NameID and without an email attribute, the code at `npm/src/saml/lib.ts:24` attempts to hash `undefined`:

```typescript
attributes.claims.idHash = dbutils.keyDigest(attributes.claims.id); // id is undefined!
```

This results in a confusing buffer-related error that gives no indication of the actual problem.

## Changes

Added an explicit check after the existing email-fallback logic:

```typescript
if (!attributes.claims.id) {
  throw new Error('SAML assertion is missing both id (NameID) and email. Ensure the IdP is configured to send at least one of these attributes.');
}
```

Closes #3812

## Test Plan

- Configure an IdP to send a SAML assertion without NameID and without email
- Verify that the error message is now descriptive instead of a buffer error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced SAML response validation to properly error when required identity attributes are missing, preventing downstream processing failures with incomplete data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->