### PR TITLE
fix(scim): dedupe users by userName (lowercased) and return scimType=uniqueness on 409

### DIFF
--- a/npm/src/directory-sync/scim/DirectoryUsers.ts
+++ b/npm/src/directory-sync/scim/DirectoryUsers.ts
@@ -32,12 +32,18 @@ export class DirectoryUsers {
 
   public async create(directory: Directory, body: any): Promise<DirectorySyncResponse> {
     const userAttributes = extractStandardUserAttributes(body);
+    const { userName } = body as { userName: string };
 
-    // Check if the user already exists
-    const { data: users } = await this.users.search(userAttributes.email, directory.id);
+    // Dedupe by userName (uniqueness=server) instead of email (uniqueness=none).
+    const { data: users } = await this.users.search(userName, directory.id);
 
     if (users && users.length > 0) {
-      return this.respondWithError({ code: 409, message: 'User already exists' });
+      // RFC 7644 §3.12: scimType=uniqueness so the IdP retries as PATCH.
+      return this.respondWithError({
+        code: 409,
+        message: 'User already exists',
+        scimType: 'uniqueness',
+      });
     }
 
     const newUser = {
@@ -172,11 +178,12 @@ export class DirectoryUsers {
     };
   }
 
-  private respondWithError(error: ApiError | null) {
+  private respondWithError(error: (ApiError & { scimType?: string }) | null) {
     return {
       status: error ? error.code : 500,
       data: {
         schemas: ['urn:ietf:params:scim:api:messages:2.0:Error'],
+        ...(error?.scimType ? { scimType: error.scimType } : {}),
         detail: error ? error.message : 'Internal Server Error',
       },
     };

--- a/npm/src/directory-sync/scim/DirectoryUsers.ts
+++ b/npm/src/directory-sync/scim/DirectoryUsers.ts
@@ -31,8 +31,13 @@ export class DirectoryUsers {
   }
 
   public async create(directory: Directory, body: any): Promise<DirectorySyncResponse> {
+    const userName = body?.userName;
+
+    if (!userName || typeof userName !== 'string') {
+      return this.respondWithError({ code: 400, message: 'userName is required' });
+    }
+
     const userAttributes = extractStandardUserAttributes(body);
-    const { userName } = body as { userName: string };
 
     // Dedupe by userName (uniqueness=server) instead of email (uniqueness=none).
     const { data: users } = await this.users.search(userName, directory.id);
@@ -78,11 +83,15 @@ export class DirectoryUsers {
   public async update(directory: Directory, user: User, body: any): Promise<DirectorySyncResponse> {
     const userAttributes = extractStandardUserAttributes(body);
 
-    const { data: updatedUser } = await this.users.update(user.id, {
-      ...userAttributes,
-      id: user.id,
-      raw: 'rawAttributes' in body ? body.rawAttributes : body,
-    });
+    const { data: updatedUser } = await this.users.update(
+      user.id,
+      {
+        ...userAttributes,
+        id: user.id,
+        raw: 'rawAttributes' in body ? body.rawAttributes : body,
+      },
+      directory.id
+    );
 
     await sendEvent('user.updated', { directory, user: updatedUser }, this.callback);
 
@@ -113,11 +122,15 @@ export class DirectoryUsers {
       };
     }
 
-    const { data: updatedUser } = await this.users.update(user.id, {
-      ...user,
-      ...attributes,
-      raw: updateRawUserAttributes(user.raw, rawAttributes),
-    });
+    const { data: updatedUser } = await this.users.update(
+      user.id,
+      {
+        ...user,
+        ...attributes,
+        raw: updateRawUserAttributes(user.raw, rawAttributes),
+      },
+      directory.id
+    );
 
     await sendEvent('user.updated', { directory, user: updatedUser }, this.callback);
 

--- a/npm/src/directory-sync/scim/Users.ts
+++ b/npm/src/directory-sync/scim/Users.ts
@@ -13,7 +13,7 @@ export class Users extends Base {
   public async create(user: User & { directoryId: string }): Promise<Response<User>> {
     const { directoryId, id } = user;
     // Index by userName (RFC 7643: uniqueness=server, caseExact=false) instead of email.
-    const indexValue = (user.raw?.userName ?? user.email).toLowerCase();
+    const indexValue = (user.raw?.userName || user.email).toLowerCase();
 
     try {
       await this.store('users').put(
@@ -117,7 +117,7 @@ export class Users extends Base {
   }
 
   // Update the user data
-  public async update(id: string, user: User): Promise<Response<User>> {
+  public async update(id: string, user: User, directoryId: string): Promise<Response<User>> {
     const { raw } = user;
 
     raw['id'] = id;
@@ -127,8 +127,21 @@ export class Users extends Base {
       raw,
     };
 
+    const indexValue = (updatedUser.raw?.userName || updatedUser.email).toLowerCase();
+
     try {
-      await this.store('users').put(id, updatedUser);
+      await this.store('users').put(
+        id,
+        updatedUser,
+        {
+          name: indexNames.directoryIdUsername,
+          value: keyFromParts(directoryId, indexValue),
+        },
+        {
+          name: indexNames.directoryId,
+          value: directoryId,
+        }
+      );
       return { data: updatedUser, error: null };
     } catch (err: any) {
       return apiError(err);

--- a/npm/src/directory-sync/scim/Users.ts
+++ b/npm/src/directory-sync/scim/Users.ts
@@ -11,7 +11,9 @@ export class Users extends Base {
 
   // Create a new user
   public async create(user: User & { directoryId: string }): Promise<Response<User>> {
-    const { directoryId, id, email } = user;
+    const { directoryId, id } = user;
+    // Index by userName (RFC 7643: uniqueness=server, caseExact=false) instead of email.
+    const indexValue = (user.raw?.userName ?? user.email).toLowerCase();
 
     try {
       await this.store('users').put(
@@ -19,7 +21,7 @@ export class Users extends Base {
         user,
         {
           name: indexNames.directoryIdUsername,
-          value: keyFromParts(directoryId, email),
+          value: keyFromParts(directoryId, indexValue),
         },
         {
           name: indexNames.directoryId,
@@ -155,7 +157,8 @@ export class Users extends Base {
     try {
       const { data: users } = await this.store('users').getByIndex({
         name: indexNames.directoryIdUsername,
-        value: keyFromParts(directoryId, userName),
+        // Lowercase to match the index built in create() (RFC 7643: caseExact=false).
+        value: keyFromParts(directoryId, userName.toLowerCase()),
       });
 
       return { data: users, error: null };

--- a/npm/test/dsync/users.test.ts
+++ b/npm/test/dsync/users.test.ts
@@ -571,4 +571,91 @@ tap.test('Directory users /', async (t) => {
       );
     });
   });
+
+  t.test('userName-based dedup contract /', async (t) => {
+    t.afterEach(async () => {
+      directorySync.users.setTenantAndProduct(directory.tenant, directory.product);
+      await directorySync.users.deleteAll(directory.id);
+    });
+
+    t.test('POST duplicate userName should return 409 with scimType=uniqueness', async (t) => {
+      await directorySync.requests.handle(requests.create(directory, users[0]));
+
+      const { status, data } = await directorySync.requests.handle(requests.create(directory, users[0]));
+
+      t.equal(status, 409);
+      t.equal(data.scimType, 'uniqueness');
+      t.equal(data.detail, 'User already exists');
+    });
+
+    t.test('POST same userName different email should return 409', async (t) => {
+      await directorySync.requests.handle(requests.create(directory, users[0]));
+
+      const { status } = await directorySync.requests.handle(
+        requests.create(directory, {
+          ...users[0],
+          emails: [{ primary: true, value: 'different@example.com', type: 'work' }],
+        })
+      );
+
+      t.equal(status, 409);
+    });
+
+    t.test('POST different userName same email should return 201 (LEV-956)', async (t) => {
+      await directorySync.requests.handle(requests.create(directory, users[0]));
+
+      const { status } = await directorySync.requests.handle(
+        requests.create(directory, {
+          ...users[0],
+          userName: 'different-user@boxyhq.com',
+        })
+      );
+
+      t.equal(status, 201);
+    });
+
+    t.test('POST case-insensitive userName match should return 409', async (t) => {
+      await directorySync.requests.handle(requests.create(directory, users[0]));
+
+      const { status } = await directorySync.requests.handle(
+        requests.create(directory, {
+          ...users[0],
+          userName: users[0].userName.toUpperCase(),
+        })
+      );
+
+      t.equal(status, 409);
+    });
+
+    t.test('PUT rename then POST with old userName should return 201', async (t) => {
+      const { data: created } = await directorySync.requests.handle(requests.create(directory, users[0]));
+
+      await directorySync.requests.handle(
+        requests.updateById(directory, created.id, {
+          ...users[0],
+          userName: 'renamed@boxyhq.com',
+        })
+      );
+
+      const { status } = await directorySync.requests.handle(
+        requests.create(directory, {
+          ...users[2],
+          userName: users[0].userName,
+        })
+      );
+
+      t.equal(status, 201);
+    });
+
+    t.test('POST without userName should return 400', async (t) => {
+      const { userName, ...userWithoutUserName } = users[0];
+
+      const { status, data } = await directorySync.requests.handle(
+        requests.create(directory, userWithoutUserName)
+      );
+
+      t.equal(status, 400);
+      t.equal(data.detail, 'userName is required');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

`DirectoryUsers.create()` deduplicates POST /Users on `userAttributes.email`, and `Users` indexes/searches records by raw email. Per RFC 7643 §4.1.1, this is the wrong attribute: `emails[].value` carries `uniqueness=none`; the canonical unique attribute on User is `userName` (`uniqueness=server`). Using a non-unique attribute as the unique key produces false 409 conflicts. The 409 response also omits `scimType`, which RFC 7644 §3.12 requires for uniqueness conflicts.

**Changes:**
- **Users.ts**: Index by `(raw.userName ?? email).toLowerCase()` instead of email; lowercase the search input
- **DirectoryUsers.ts**: Dedupe on `body.userName` instead of `userAttributes.email`; return `scimType: "uniqueness"` on 409

## What does this PR do?

Fixes two SCIM 2.0 spec deviations in `DirectoryUsers.create()` and `Users` that produce false 409 conflicts and infinite IdP retry loops.

### Problem Details

Per [RFC 7643 §4.1.1](https://datatracker.ietf.org/doc/html/rfc7643#section-4.1.1):

| Attribute | `uniqueness` | `caseExact` |
|---|---|---|
| `userName` | `server` | `false` |
| `emails[].value` | `none` | n/a |

Polis was indexing User records by `email` and deduping POSTs on `userAttributes.email`. Using `emails[].value` (`uniqueness=none`) as the unique index produces false 409 conflicts whenever `userName` and `emails[].value` diverge — which is spec-compliant IdP behavior, not an edge case:

- `userName` can change independently of `email` (renames, login changes).
- `userName` is `caseExact=false`; IdPs may ship the same logical userName in different casing across requests.
- `emails[].value` is not required to track changes to `userName`, and the spec doesn't promise it will.

Additionally, [RFC 7644 §3.3](https://datatracker.ietf.org/doc/html/rfc7644#section-3.3) and [§3.12](https://datatracker.ietf.org/doc/html/rfc7644#section-3.12) require `scimType="uniqueness"` on 409 responses for uniqueness conflicts so the IdP can switch to PATCH on the existing resource. The current implementation omits this field. IdPs that depend on it (Microsoft Entra in particular) retry POST indefinitely on legitimate already-exists conditions.

### Real-World Impact

A POST /Users with a renamed `userName` but the same `emails[0].value` is rejected as a duplicate against the prior record:

**Stored:** `userName=alice@example.com`, `emails[0].value=alice@example.com`

**Request:** `POST /Users` with `userName=alice2@example.com`, `emails[0].value=alice@example.com`

**Current (incorrect) response:** HTTP 409
```json
{
  "schemas": ["urn:ietf:params:scim:api:messages:2.0:Error"],
  "detail": "User already exists"
}
```

The IdP can't interpret the bare 409 (no `scimType`) and retries POST indefinitely. The legitimately-renamed user is permanently locked out.

**Expected response (after this fix):** HTTP 201 Created — the lookup is now by `userName=alice2@example.com`, finds no match, and creates the new resource. When a true duplicate is detected, the 409 includes `scimType="uniqueness"` so the IdP knows to switch to PATCH.

### Solution

**`Users.ts` (`create`):**
```typescript
// Before
const { directoryId, id, email } = user;
// ...
value: keyFromParts(directoryId, email),

// After
const { directoryId, id } = user;
// Index by userName (RFC 7643: uniqueness=server, caseExact=false) instead of email.
const indexValue = (user.raw?.userName ?? user.email).toLowerCase();
// ...
value: keyFromParts(directoryId, indexValue),
```

**`Users.ts` (`search`):**
```typescript
// Before
value: keyFromParts(directoryId, userName),

// After
// Lowercase to match the index built in create() (RFC 7643: caseExact=false).
value: keyFromParts(directoryId, userName.toLowerCase()),
```

**`DirectoryUsers.ts` (`create`):**
```typescript
// Before
const { data: users } = await this.users.search(userAttributes.email, directory.id);
if (users && users.length > 0) {
  return this.respondWithError({ code: 409, message: 'User already exists' });
}

// After
const { userName } = body as { userName: string };
// Dedupe by userName (uniqueness=server) instead of email (uniqueness=none).
const { data: users } = await this.users.search(userName, directory.id);
if (users && users.length > 0) {
  // RFC 7644 §3.12: scimType=uniqueness so the IdP retries as PATCH.
  return this.respondWithError({
    code: 409,
    message: 'User already exists',
    scimType: 'uniqueness',
  });
}
```

`respondWithError` signature is widened to accept an optional `scimType` passthrough.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. **Test Case 1 — Rename with shared email:**
   ```
   Pre-populate: userName=alice@example.com, emails[0].value=alice@example.com
   POST /Users with userName=alice2@example.com, emails[0].value=alice@example.com
   Expected: 201 Created (no false 409)
   ```

2. **Test Case 2 — Same userName, different casing:**
   ```
   Pre-populate: userName=Alice@example.com
   POST /Users with userName=alice@example.com (different case)
   Expected: 409 with scimType="uniqueness" (case-insensitive match per caseExact=false)
   ```

3. **Test Case 3 — Bona fide duplicate:**
   ```
   POST /Users with userName=alice@example.com (twice)
   Expected: First → 201; second → 409 with scimType="uniqueness"
   ```

- [ ] Existing unit tests (no changes needed; behavior change requires new tests)
- [ ] e2e tests in `e2e/api/scim/v2.0/users.spec.ts` — happy to add if maintainers prefer

## Migration / compatibility

Existing records stay keyed under their original casing; this change does not migrate the store. The next re-provision under the same canonical `userName` produces one transitional record under the new lowercased index, after which the record is stable. Operators wanting to clean up orphan records can do so via a one-off script — out of scope for this PR.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code and corrected any misspellings
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective — happy to add e2e tests if maintainers prefer
- [x] Existing unit tests pass locally with my changes

## Additional Notes

- This is a SCIM 2.0 spec compliance fix. The fix changes which attribute Polis uses for the server-side uniqueness check, aligning with RFC 7643's specification that `userName` is the canonical unique attribute on User.
- The case-sensitivity portion of this same root cause was reported in #3559 for Groups. The Groups fix is mechanically equivalent but kept out of scope here for review tractability — happy to follow up with a Groups PR after this lands.

